### PR TITLE
Misc. test cleanup, including filesystem paths for Windows 

### DIFF
--- a/cli/src/targets.ts
+++ b/cli/src/targets.ts
@@ -100,7 +100,11 @@ export class Targets {
 	}
 
 	public getRelative(fullPath: string) {
-		return path.relative(this.cwd, fullPath);
+		return Targets.getPosixyPath(path.relative(this.cwd, fullPath));
+	}
+
+	private static getPosixyPath(filePath: string): string {
+		return filePath.split(path.sep).join(path.posix.sep);
 	}
 
 	private storeResolved(localPath: string, ileObject: ILEObject) {
@@ -144,7 +148,7 @@ export class Targets {
 	}
 
 	public removeObjectByPath(localPath: string) {
-		const resolvedObject = this.resolvedObjects[localPath];
+		const resolvedObject = this.resolvedObjects[Targets.getPosixyPath(localPath)];
 		const pathDetail = path.parse(localPath);
 
 		if (resolvedObject) {
@@ -1359,10 +1363,10 @@ export class Targets {
 		currentTarget.relativePath = undefined;
 
 		// Store new resolved path for this object
-		this.storeResolved(path.join(this.cwd, `${currentTarget.name}.PGM`), currentTarget);
+		this.storeResolved(path.posix.join(this.cwd, `${currentTarget.name}.PGM`), currentTarget);
 
 		// Then we can resolve the same path again
-		const newModule = this.resolveObject(path.join(this.cwd, basePath));
+		const newModule = this.resolveObject(path.posix.join(this.cwd, basePath));
 		// Force it as a module
 		newModule.type = `MODULE`;
 
@@ -1413,7 +1417,7 @@ export class Targets {
 	}
 
 	public getResolvedObject(fullPath: string): ILEObject {
-		return this.resolvedObjects[fullPath];
+		return this.resolvedObjects[Targets.getPosixyPath(fullPath)];
 	}
 
 	/**

--- a/cli/src/targets.ts
+++ b/cli/src/targets.ts
@@ -103,7 +103,7 @@ export class Targets {
 		return Targets.getPosixyPath(path.relative(this.cwd, fullPath));
 	}
 
-	private static getPosixyPath(filePath: string): string {
+	public static getPosixyPath(filePath: string): string {
 		return filePath.split(path.sep).join(path.posix.sep);
 	}
 

--- a/cli/test/autofix.test.ts
+++ b/cli/test/autofix.test.ts
@@ -10,13 +10,13 @@ test(`Auto rename RPGLE program and include and fix-include infos`, async () => 
 
   // First step is to rename the files
 
-	let targets = new Targets(cwd);
+  let targets = new Targets(cwd);
 	targets.setSuggestions({renames: true});
 
   const initialFiles = getFiles(cwd, scanGlob);
-	await Promise.allSettled(initialFiles.map(f => targets.handlePath(f)));
+  await Promise.allSettled(initialFiles.map(f => targets.handlePath(f)));
 
-	targets.resolveBinder();
+  targets.resolveBinder();
 
   const oldPrograms = targets.getParentObjects(`PGM`);
   expect(oldPrograms.length).toBe(0); //Because the initial project extension is wrong
@@ -46,7 +46,7 @@ test(`Auto rename RPGLE program and include and fix-include infos`, async () => 
     type: "rename",
     change: {
       rename: {
-        path: "/Users/barry/Repos/sourceorbit/from_qsys/qsqlsrc/super_long_dept_name.sql",
+        path: Targets.getPosixyPath(targets.getCwd() + "/qsqlsrc/super_long_dept_name.sql"),
         newName: "dept.table",
       },
     },
@@ -58,7 +58,7 @@ test(`Auto rename RPGLE program and include and fix-include infos`, async () => 
     type: "rename",
     change: {
       rename: {
-        path: "/Users/barry/Repos/sourceorbit/from_qsys/qsqlsrc/empmst.sql",
+        path: Targets.getPosixyPath(targets.getCwd() + "/qsqlsrc/empmst.sql"),
         newName: "empmst.table",
       },
     },
@@ -70,7 +70,7 @@ test(`Auto rename RPGLE program and include and fix-include infos`, async () => 
     type: "rename",
     change: {
       rename: {
-        path: "/Users/barry/Repos/sourceorbit/from_qsys/qprotosrc/errortable.rpgle",
+        path: Targets.getPosixyPath(targets.getCwd() + "/qprotosrc/errortable.rpgle"),
         newName: "errortable.rpgleinc",
       },
     },
@@ -87,7 +87,7 @@ test(`Auto rename RPGLE program and include and fix-include infos`, async () => 
     type: "rename",
     change: {
       rename: {
-        path: "/Users/barry/Repos/sourceorbit/from_qsys/qrpglesrc/payroll.rpgle",
+        path: Targets.getPosixyPath(targets.getCwd() + "/qrpglesrc/payroll.rpgle"),
         newName: "payroll.pgm.rpgle",
       },
     },
@@ -101,9 +101,9 @@ test(`Auto rename RPGLE program and include and fix-include infos`, async () => 
 	targets.setSuggestions({renames: true});
 
   const newFiles = getFiles(cwd, scanGlob);
-	await Promise.allSettled(newFiles.map(f => targets.handlePath(f)));
+  await Promise.allSettled(newFiles.map(f => targets.handlePath(f)));
 
-	targets.resolveBinder();
+  targets.resolveBinder();
 
   const newPrograms = targets.getParentObjects(`PGM`);
   expect(newPrograms.length).toBe(1); //Because the extension was fixed
@@ -129,13 +129,13 @@ test(`Fix includes in same directory`, async () => {
 
   // First step is to rename the files
 
-	let targets = new Targets(cwd);
+  let targets = new Targets(cwd);
 	targets.setSuggestions({includes: true});
 
   const initialFiles = getFiles(cwd, scanGlob);
-	await Promise.allSettled(initialFiles.map(f => targets.handlePath(f)));
+  await Promise.allSettled(initialFiles.map(f => targets.handlePath(f)));
 
-	targets.resolveBinder();
+  targets.resolveBinder();
 
   const programs = targets.getParentObjects(`PGM`);
   expect(programs.length).toBe(1);

--- a/cli/test/fixtures/targets.ts
+++ b/cli/test/fixtures/targets.ts
@@ -2,111 +2,111 @@ import { assert, expect, test } from 'vitest'
 import { Targets } from '../../src/targets'
 import path from 'path';
 
-export const cwd = path.join(`/`, `projects`);
+export const cwd = path.posix.join(`/`, `projects`);
 
 export function baseTargets(withDeps = false) {
   const targets = new Targets(cwd);
 
   // Command object for PROGRAMA.PGM
-  const programACommand = targets.resolveObject(path.join(cwd, `qcmdsrc`, `programA.cmd`));
+  const programACommand = targets.resolveObject(path.posix.join(cwd, `qcmdsrc`, `programA.cmd`));
   expect(programACommand.name).toBe(`PROGRAMA`);
   expect(programACommand.type).toBe(`CMD`);
   expect(programACommand.extension).toBe(`cmd`);
-  expect(programACommand.relativePath).toBe(path.join(`qcmdsrc`, `programA.cmd`));
+  expect(programACommand.relativePath).toBe(path.posix.join(`qcmdsrc`, `programA.cmd`));
 
   // Command object that goes unused.
-  const unusedCmd = targets.resolveObject(path.join(cwd, `qcmdsrc`, `unused.cmd`));
+  const unusedCmd = targets.resolveObject(path.posix.join(cwd, `qcmdsrc`, `unused.cmd`));
   expect(unusedCmd.name).toBe(`UNUSED`);
   expect(unusedCmd.type).toBe(`CMD`);
   expect(unusedCmd.extension).toBe(`cmd`);
-  expect(unusedCmd.relativePath).toBe(path.join(`qcmdsrc`, `unused.cmd`));
+  expect(unusedCmd.relativePath).toBe(path.posix.join(`qcmdsrc`, `unused.cmd`));
 
   // Program object
-  const programA = targets.resolveObject(path.join(cwd, `qrpglesrc`, `programA.pgm.rpgle`));
+  const programA = targets.resolveObject(path.posix.join(cwd, `qrpglesrc`, `programA.pgm.rpgle`));
   expect(programA.name).toBe(`PROGRAMA`);
   expect(programA.type).toBe(`PGM`);
   expect(programA.extension).toBe(`rpgle`);
-  expect(programA.relativePath).toBe(path.join(`qrpglesrc`, `programA.pgm.rpgle`));
+  expect(programA.relativePath).toBe(path.posix.join(`qrpglesrc`, `programA.pgm.rpgle`));
 
   // Program object, imports TOLOWER
-  const programB = targets.resolveObject(path.join(cwd, `qrpglesrc`, `programB.pgm.sqlrpgle`));
+  const programB = targets.resolveObject(path.posix.join(cwd, `qrpglesrc`, `programB.pgm.sqlrpgle`));
   expect(programB.name).toBe(`PROGRAMB`);
   expect(programB.type).toBe(`PGM`);
   expect(programB.extension).toBe(`sqlrpgle`);
-  expect(programB.relativePath).toBe(path.join(`qrpglesrc`, `programB.pgm.sqlrpgle`));
+  expect(programB.relativePath).toBe(path.posix.join(`qrpglesrc`, `programB.pgm.sqlrpgle`));
   programB.imports = [`TOLOWER`];
 
   // Program object, imports TOLOWER
-  const programC = targets.resolveObject(path.join(cwd, `qrpglesrc`, `programC.pgm.sqlrpgle`));
+  const programC = targets.resolveObject(path.posix.join(cwd, `qrpglesrc`, `programC.pgm.sqlrpgle`));
   expect(programC.name).toBe(`PROGRAMC`);
   expect(programC.type).toBe(`PGM`);
   expect(programC.extension).toBe(`sqlrpgle`);
-  expect(programC.relativePath).toBe(path.join(`qrpglesrc`, `programC.pgm.sqlrpgle`));
+  expect(programC.relativePath).toBe(path.posix.join(`qrpglesrc`, `programC.pgm.sqlrpgle`));
   programC.imports = [`TOUPPER`];
 
   // Module MODULEA.MODULE, which is not used at all.
-  const moduleA = targets.resolveObject(path.join(cwd, `qrpglesrc`, `moduleA.rpgle`));
+  const moduleA = targets.resolveObject(path.posix.join(cwd, `qrpglesrc`, `moduleA.rpgle`));
   expect(moduleA.name).toBe(`MODULEA`);
   expect(moduleA.type).toBe(`MODULE`);
   expect(moduleA.extension).toBe(`rpgle`);
-  expect(moduleA.relativePath).toBe(path.join(`qrpglesrc`, `moduleA.rpgle`));
+  expect(moduleA.relativePath).toBe(path.posix.join(`qrpglesrc`, `moduleA.rpgle`));
   moduleA.exports = [`SUMNUMS`];
   
   // Module MODULEB.MODULE, which exports TOLOWER
-  const moduleB = targets.resolveObject(path.join(cwd, `qrpglesrc`, `moduleB.sqlrpgle`));
+  const moduleB = targets.resolveObject(path.posix.join(cwd, `qrpglesrc`, `moduleB.sqlrpgle`));
   expect(moduleB.name).toBe(`MODULEB`);
   expect(moduleB.type).toBe(`MODULE`);
   expect(moduleB.extension).toBe(`sqlrpgle`);
-  expect(moduleB.relativePath).toBe(path.join(`qrpglesrc`, `moduleB.sqlrpgle`));
+  expect(moduleB.relativePath).toBe(path.posix.join(`qrpglesrc`, `moduleB.sqlrpgle`));
   moduleB.exports = [`TOLOWER`];
 
   // SRVPGMA.SRVPGM, which imports TOLOWER from MODULEB.MODULE and therefore exports TOLOWER
-  const srvpgmAModule = targets.resolveObject(path.join(cwd, `qsrvsrc`, `srvpgmA.bnd`));
+  const srvpgmAModule = targets.resolveObject(path.posix.join(cwd, `qsrvsrc`, `srvpgmA.bnd`));
   expect(srvpgmAModule.name).toBe(`SRVPGMA`);
   expect(srvpgmAModule.type).toBe(`SRVPGM`);
   expect(srvpgmAModule.extension).toBe(`bnd`);
-  expect(srvpgmAModule.relativePath).toBe(path.join(`qsrvsrc`, `srvpgmA.bnd`));
+  expect(srvpgmAModule.relativePath).toBe(path.posix.join(`qsrvsrc`, `srvpgmA.bnd`));
   srvpgmAModule.imports = [`TOLOWER`];
   srvpgmAModule.exports = [`TOLOWER`];
   
   // FILEA.FILE
-  const fileA = targets.resolveObject(path.join(cwd, `qddssrc`, `fileA.sql`));
+  const fileA = targets.resolveObject(path.posix.join(cwd, `qddssrc`, `fileA.sql`));
   expect(fileA.name).toBe(`FILEA`);
   expect(fileA.type).toBe(`FILE`);
   expect(fileA.extension).toBe(`sql`);
-  expect(fileA.relativePath).toBe(path.join(`qddssrc`, `fileA.sql`));
+  expect(fileA.relativePath).toBe(path.posix.join(`qddssrc`, `fileA.sql`));
   
   // FILEB.FILE
-  const fileB = targets.resolveObject(path.join(cwd, `qddssrc`, `fileB.pf`));
+  const fileB = targets.resolveObject(path.posix.join(cwd, `qddssrc`, `fileB.pf`));
   expect(fileB.name).toBe(`FILEB`);
   expect(fileB.type).toBe(`FILE`);
   expect(fileB.extension).toBe(`pf`);
-  expect(fileB.relativePath).toBe(path.join(`qddssrc`, `fileB.pf`));
+  expect(fileB.relativePath).toBe(path.posix.join(`qddssrc`, `fileB.pf`));
 
   // ORDENTSRV.SRVPGM, which exports/imports FIXTOTALS
-  const ORDENTSRV = targets.resolveObject(path.join(cwd, `qbndsrc`, `ordentsrv.binder`));
+  const ORDENTSRV = targets.resolveObject(path.posix.join(cwd, `qbndsrc`, `ordentsrv.binder`));
   ORDENTSRV.exports = [`FIXTOTALS`];
   ORDENTSRV.imports = [`FIXTOTALS`];
   expect(ORDENTSRV.name).toBe(`ORDENTSRV`);
   expect(ORDENTSRV.type).toBe(`SRVPGM`);
   expect(ORDENTSRV.extension).toBe(`binder`);
-  expect(ORDENTSRV.relativePath).toBe(path.join(`qbndsrc`, `ordentsrv.binder`));
+  expect(ORDENTSRV.relativePath).toBe(path.posix.join(`qbndsrc`, `ordentsrv.binder`));
 
   // ORDENTMOD.MODULE which exports FIXTOTALS
-  const ORDENTMOD = targets.resolveObject(path.join(cwd, `qrpglesrc`, `ordentmod.rpgle`));
+  const ORDENTMOD = targets.resolveObject(path.posix.join(cwd, `qrpglesrc`, `ordentmod.rpgle`));
   ORDENTMOD.exports = [`FIXTOTALS`];
   expect(ORDENTMOD.name).toBe(`ORDENTMOD`);
   expect(ORDENTMOD.type).toBe(`MODULE`);
   expect(ORDENTMOD.extension).toBe(`rpgle`);
-  expect(ORDENTMOD.relativePath).toBe(path.join(`qrpglesrc`, `ordentmod.rpgle`));
+  expect(ORDENTMOD.relativePath).toBe(path.posix.join(`qrpglesrc`, `ordentmod.rpgle`));
 
   // UNUSEDSRV.SRVPGM, which exports BIGNOPE and is not used.
-  const UNUSEDSRV = targets.resolveObject(path.join(cwd, `qbndsrc`, `unusedsrv.binder`));
+  const UNUSEDSRV = targets.resolveObject(path.posix.join(cwd, `qbndsrc`, `unusedsrv.binder`));
   UNUSEDSRV.exports = [`BIGNOPE`];
   expect(UNUSEDSRV.name).toBe(`UNUSEDSRV`);
   expect(UNUSEDSRV.type).toBe(`SRVPGM`);
   expect(UNUSEDSRV.extension).toBe(`binder`);
-  expect(UNUSEDSRV.relativePath).toBe(path.join(`qbndsrc`, `unusedsrv.binder`));
+  expect(UNUSEDSRV.relativePath).toBe(path.posix.join(`qbndsrc`, `unusedsrv.binder`));
 
   if (withDeps) {
     targets.createOrAppend(programA, fileA);
@@ -130,29 +130,29 @@ export function multiModuleObjects() {
   const targets = new Targets(cwd);
 
   // Base program object MYWEBAPP.PGM
-  const myWebApp = targets.resolveObject(path.join(cwd, `qrpglesrc`, `mywebapp.pgm.rpgle`));
+  const myWebApp = targets.resolveObject(path.posix.join(cwd, `qrpglesrc`, `mywebapp.pgm.rpgle`));
   myWebApp.imports = [`ROUTEHANDLERA`, `ROUTEHANDLERB`, `JWT_MIDDLEWARE`, `IL_LISTEN`, `IL_RESPONSEWRITESTREAM`];
 
   // Module that is required by the MYWEBAPP.PGM
-  const handlerAMod = targets.resolveObject(path.join(cwd, `qrpglesrc`, `handlerA.rpgle`));
+  const handlerAMod = targets.resolveObject(path.posix.join(cwd, `qrpglesrc`, `handlerA.rpgle`));
   handlerAMod.exports = [`ROUTEHANDLERA`];
   handlerAMod.imports = [`JSON_SQLRESULTSET`, `IL_RESPONSEWRITESTREAM`];
 
   // Another module that is required by the MYWEBAPP.PGM
-  const handlerBMod = targets.resolveObject(path.join(cwd, `qrpglesrc`, `handlerB.rpgle`));
+  const handlerBMod = targets.resolveObject(path.posix.join(cwd, `qrpglesrc`, `handlerB.rpgle`));
   handlerBMod.exports = [`ROUTEHANDLERB`];
   handlerBMod.imports = [`API_VALIDATE`, `JSON_SQLRESULTSET`, `IL_RESPONSEWRITESTREAM`];
 
   // Another module that is part of the JWTHANDLER.SRVPGM object
-  const jwtHandlerMod = targets.resolveObject(path.join(cwd, `qrpglesrc`, `jwtHandler.rpgle`));
+  const jwtHandlerMod = targets.resolveObject(path.posix.join(cwd, `qrpglesrc`, `jwtHandler.rpgle`));
   jwtHandlerMod.exports = [`JWT_MIDDLEWARE`];
 
   // Another module that is part of the JWTHANDLER.SRVPGM object
-  const validateMod = targets.resolveObject(path.join(cwd, `qrpglesrc`, `validate.rpgle`));
+  const validateMod = targets.resolveObject(path.posix.join(cwd, `qrpglesrc`, `validate.rpgle`));
   validateMod.exports = [`API_VALIDATE`];
 
   // Service program for JWTHANDLER, used by MYWEBAPP
-  const jwtHandlerSrv = targets.resolveObject(path.join(cwd, `qsrvsrc`, `utils.binder`));
+  const jwtHandlerSrv = targets.resolveObject(path.posix.join(cwd, `qsrvsrc`, `utils.binder`));
   jwtHandlerSrv.imports = [`JWT_MIDDLEWARE`, `API_VALIDATE`];
   jwtHandlerSrv.exports = [`JWT_MIDDLEWARE`, `API_VALIDATE`];
 

--- a/cli/test/project.test.ts
+++ b/cli/test/project.test.ts
@@ -101,12 +101,14 @@ describe.skipIf(files.length === 0)(`company_system tests`, () => {
 
     expect(myBinder.deps.length).toBe(2);
 
-    const bankingSrvpgm = myBinder.deps[0];
+    let deps = myBinder.deps;
+    deps.sort((a,b) => a.name.localeCompare(b.name));
+    const bankingSrvpgm = deps[0];
     expect(bankingSrvpgm.name).toBe(`BANKING`);
     expect(bankingSrvpgm.type).toBe(`SRVPGM`);
     expect(bankingSrvpgm.relativePath).toBe(`qsrvsrc/banking.bnd`);
 
-    const utilsSrvpgm = myBinder.deps[1];
+    const utilsSrvpgm = deps[1];
     expect(utilsSrvpgm.name).toBe(`UTILS`);
     expect(utilsSrvpgm.type).toBe(`SRVPGM`);
     expect(utilsSrvpgm.relativePath).toBe(`qsrvsrc/utils.bnd`);


### PR DESCRIPTION

Some test cases failed on Windows because of `C:\path\to\file` naming semantics. This PR implements normalizes the use of paths to pseudo-Posix style pathing (namely the use of `/` as the file separator), either by use of `path.posix.join()` or manually splitting and rejoining the path with the posix file separator. 