### PR TITLE
spelling of destroy() in TargetsManager

### DIFF
--- a/vs/server/src/TargetsManager.ts
+++ b/vs/server/src/TargetsManager.ts
@@ -57,7 +57,7 @@ export class TargetsManager {
     this.projects[url] = targets;
   }
 
-  static destory(workspaceUri: string) {
+  static destroy(workspaceUri: string) {
     const uri = URI.parse(workspaceUri);
     const url = uri.fsPath;
 

--- a/vs/server/src/fileSystemListener.ts
+++ b/vs/server/src/fileSystemListener.ts
@@ -20,7 +20,7 @@ export function setupFsListener(connection: Connection) {
 		connection.console.log(JSON.stringify(_event, null, 2));
 
 		for (const removed of _event.removed) {
-			TargetsManager.destory(removed.uri);
+			TargetsManager.destroy(removed.uri);
 		}
 
 		// Commented out since we don't read entire projects on load


### PR DESCRIPTION
Fixed the spelling as discussed.  Tested