### PR TITLE
Feature/bob_keep_attrs

### DIFF
--- a/cli/src/builders/bob.ts
+++ b/cli/src/builders/bob.ts
@@ -37,15 +37,14 @@ export class BobProject {
 		for (const subdir in this.dirTargets) {
 			const targets = this.dirTargets[subdir];
 			const currentRulesFile = path.join(subdir, `Rules.mk`);
+			const currentFullPath = path.join(this.targets.getCwd(), currentRulesFile);
 			let rulesContent: string[] = [];
 
-			if (existsSync(path.join(this.targets.getCwd(), currentRulesFile))) {
-				rulesContent = readFileSync(currentRulesFile, { encoding: `utf-8` }).split(`\n`);
+			if (existsSync(currentFullPath)) {
+				rulesContent = readFileSync(currentFullPath, { encoding: `utf-8` }).split(`\n`);
 			}
 
 			const rulesFile = new RulesFile(subdir, rulesContent);
-
-			let lines: string[] = [];
 
 			for (let target of targets) {
 				rulesFile.applyRule(target);
@@ -86,7 +85,7 @@ class RulesFile {
 
 		const existingLine = this.parsed.find(r => r.target === objName && r.isSetting !== true);
 
-		const lineContent = `${path.relative(this.subdir, target.relativePath)} ${target.deps.filter(d => d.reference !== true).map(d => `${d.systemName}.${d.type}`).join(` `)}`;
+		const lineContent = `${path.relative(this.subdir, target.relativePath)} ${target.deps.filter(d => d.reference !== true).map(d => `${d.systemName}.${d.type}`).join(` `)}`.trimEnd();
 
 		if (existingLine) {
 			existingLine.ogLine = `${objName}: ${lineContent}`;

--- a/cli/src/builders/bob.ts
+++ b/cli/src/builders/bob.ts
@@ -61,7 +61,7 @@ interface Rule {
 	ogLine: string;
 	target?: String,
 	content?: String,
-	isSetting?: boolean,
+	isUserWritten?: boolean,
 };
 
 class RulesFile {
@@ -73,7 +73,7 @@ class RulesFile {
 				const [target, content] = line.split(`:`);
 				currentRule.target = target.trim().toUpperCase();
 				currentRule.content = content.trim();
-				currentRule.isSetting = content.includes(`=`);
+				currentRule.isUserWritten = content.includes(`=`) || content.trimStart().startsWith(`#`);
 			}
 
 			this.parsed.push(currentRule);
@@ -83,7 +83,7 @@ class RulesFile {
 	applyRule(target: ILEObjectTarget) {
 		const objName = `${target.systemName}.${target.type}`;
 
-		const existingLine = this.parsed.find(r => r.target === objName && r.isSetting !== true);
+		const existingLine = this.parsed.find(r => r.target === objName && r.isUserWritten !== true);
 
 		const lineContent = `${path.relative(this.subdir, target.relativePath)} ${target.deps.filter(d => d.reference !== true).map(d => `${d.systemName}.${d.type}`).join(` `)}`.trimEnd();
 

--- a/cli/test/bobWithExistingFiles.test.ts
+++ b/cli/test/bobWithExistingFiles.test.ts
@@ -1,0 +1,58 @@
+import { assert, beforeAll, describe, expect, test } from 'vitest';
+
+import { Targets } from '../src/targets'
+import path from 'path';
+import { MakeProject } from '../src/builders/make';
+import { getFiles } from '../src/utils';
+import { setupFixture } from './fixtures/projects';
+import { scanGlob } from '../src/extensions';
+import { writeFileSync } from 'fs';
+import { BobProject } from '../src';
+
+const cwd = setupFixture(`pseudo`);
+
+// This issue was occuring when you had two files with the same name, but different extensions.
+
+let files = getFiles(cwd, scanGlob);
+
+describe.skipIf(files.length === 0)(`bob Rules.mk tests`, () => {
+  const targets = new Targets(cwd);
+  targets.setSuggestions({ renames: true, includes: true })
+
+  beforeAll(async () => {
+    targets.loadObjectsFromPaths(files);
+    const parsePromises = files.map(f => targets.parseFile(f));
+    await Promise.all(parsePromises);
+
+    expect(targets.getTargets().length).toBeGreaterThan(0);
+    targets.resolveBinder();
+  });
+
+  test(`bob to not overwrite any pre-existing rules for targets`, () => {
+    const project = new BobProject(targets);
+
+    const files = project.createRules();
+
+    const baseRules = files[`Rules.mk`].split(`\n`);
+
+    expect(baseRules).toBeDefined();
+    expect(baseRules[0]).toContain(`SUBDIRS =`);
+    expect(baseRules[0]).toContain(`qobjs`);
+    expect(baseRules[0]).toContain(`qrpglesrc`);
+
+    const qobjRules = files[`qobjs/Rules.mk`].split(`\n`);
+
+    expect(qobjRules).toBeDefined();
+    expect(qobjRules).toContain(`MYTHING.DTAARA:text=Hello world`);
+    expect(qobjRules).toContain(`MSTDSP.FILE: mstdsp.dspf`);
+
+    const qrpglesrcRules = files[`qrpglesrc/Rules.mk`].split(`\n`);
+
+    expect(qrpglesrcRules).toBeDefined();
+    expect(qrpglesrcRules).toContain(`TESTER.PGM: tester.pgm.rpgle MYTHING.DTAARA`);
+    expect(qrpglesrcRules).toContain(`TESTER.PGM: text = My program`);
+    expect(qrpglesrcRules).toContain(`# Other assignment`);
+    expect(qrpglesrcRules).toContain(`TESTER.PGM: bnddir:=MYBND`);
+    expect(qrpglesrcRules).toContain(`OTHER.PGM: other.pgm.sqlrpgle MSTDSP.FILE`);
+  });
+});

--- a/cli/test/environment.test.ts
+++ b/cli/test/environment.test.ts
@@ -69,7 +69,6 @@ describe(`CL parser`, () => {
     const cl = `CRTCLPGM PGM(MYLIB/MYCL) SRCFILE(MYLIB/QCLSRC) SRCMBR(MYCL)`;
     const parsed = fromCl(cl);
 
-    console.log(parsed);
     expect(parsed.command).toBe(`CRTCLPGM`);
     expect(parsed.parameters).toMatchObject({
       pgm: `MYLIB/MYCL`,
@@ -82,7 +81,6 @@ describe(`CL parser`, () => {
     const cl = `CRTCLPGM`;
     const parsed = fromCl(cl);
 
-    console.log(parsed);
     expect(parsed.command).toBe(`CRTCLPGM`);
     expect(parsed.parameters).toMatchObject({});
   });


### PR DESCRIPTION
Implements #43, which will keep custom written attributes in `Rules.mk`. The generation process will overwrite targets and their deps, or add them if they are not in the file.