### PR TITLE
Add `Generate Build File` and `Refresh` actions

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ibm/sourceorbit",
-  "version": "0.10.4",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ibm/sourceorbit",
-      "version": "0.10.4",
+      "version": "0.11.1",
       "license": "Apache 2",
       "dependencies": {
         "crc-32": "https://cdn.sheetjs.com/crc-32-latest/crc-32-latest.tgz"

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -317,5 +317,6 @@ function listDeps(cwd: string, targets: Targets, query: string) {
 export { Targets } from './targets';
 export { MakeProject } from './builders/make';
 export { BobProject } from "./builders/bob";
+export { ImpactMarkdown } from "./builders/imd" 
 export { allExtensions } from "./extensions";
 export * as Utils from './utils';

--- a/vs/client/package-lock.json
+++ b/vs/client/package-lock.json
@@ -24,7 +24,7 @@
 		},
 		"../../cli": {
 			"name": "@ibm/sourceorbit",
-			"version": "0.10.4",
+			"version": "0.11.1",
 			"dev": true,
 			"license": "Apache 2",
 			"dependencies": {

--- a/vs/client/src/extension.ts
+++ b/vs/client/src/extension.ts
@@ -38,16 +38,14 @@ export async function activate(context: ExtensionContext) {
 					return [objectViews[fsPath]];
 				});
 
+				// Project Explorer specific commands
 				context.subscriptions.push(
-					// Project Explorer specific command
 					commands.registerCommand(`vscode-sourceorbit.objects.loadProject`, async (node: SourceOrbitTreeItem) => {
 						if (node) {
 							await LanguageClientManager.reloadProject(node.workspaceFolder);
 							node.refresh();
 						}
 					}),
-
-					// Project Explorer specific command
 					commands.registerCommand(`vscode-sourceorbit.objects.autoFix`, ((node: SourceOrbitTreeItem) => {
 						if (node && node.workspaceFolder) {
 							window.showInformationMessage(`Select auto fix method for ${node.workspaceFolder.name}`, `Cancel`, `File names`, `RPG includes`).then(chosen => {
@@ -66,6 +64,26 @@ export async function activate(context: ExtensionContext) {
 							});
 						}
 					})),
+					commands.registerCommand(`vscode-sourceorbit.objects.generateBobBuildFile`, async (node: SourceOrbitTreeItem) => {
+						if (node && node.workspaceFolder) {
+							await LanguageClientManager.generateBuildFile(node.workspaceFolder, 'bob');
+						}
+					}),
+					commands.registerCommand(`vscode-sourceorbit.objects.generateMakeBuildFile`, async (node: SourceOrbitTreeItem) => {
+						if (node && node.workspaceFolder) {
+							await LanguageClientManager.generateBuildFile(node.workspaceFolder, 'make');
+						}
+					}),
+					commands.registerCommand(`vscode-sourceorbit.objects.generateImdBuildFile`, async (node: SourceOrbitTreeItem) => {
+						if (node && node.workspaceFolder) {
+							await LanguageClientManager.generateBuildFile(node.workspaceFolder, 'imd');
+						}
+					}),
+					commands.registerCommand(`vscode-sourceorbit.objects.generateJsonBuildFile`, async (node: SourceOrbitTreeItem) => {
+						if (node && node.workspaceFolder) {
+							await LanguageClientManager.generateBuildFile(node.workspaceFolder, 'json');
+						}
+					})
 				);
 			}
 		}

--- a/vs/client/src/extension.ts
+++ b/vs/client/src/extension.ts
@@ -76,6 +76,24 @@ export async function activate(context: ExtensionContext) {
 		context.subscriptions.push(
 			window.createTreeView(`gitImpactView`, { treeDataProvider: gitImpactView, showCollapseAll: true }),
 			window.createTreeView(`activeImpactView`, { treeDataProvider: activeImpactView, showCollapseAll: true }),
+			commands.registerCommand(`vscode-sourceorbit.objects.refreshGitImpactView`, (async () => {
+				if (gitImpactView.impactOf && gitImpactView.impactOf.length > 0) {
+					const workspaceFolder = workspace.getWorkspaceFolder(gitImpactView.impactOf[0]);
+					if (workspaceFolder) {
+						await LanguageClientManager.reloadProject(workspaceFolder);
+					}
+				}
+				gitImpactView.refresh();
+			})),
+			commands.registerCommand(`vscode-sourceorbit.objects.refreshActiveImpactView`, (async () => {
+				if (activeImpactView.impactOf && activeImpactView.impactOf.length > 0) {
+					const workspaceFolder = workspace.getWorkspaceFolder(activeImpactView.impactOf[0]);
+					if (workspaceFolder) {
+						await LanguageClientManager.reloadProject(workspaceFolder);
+					}
+				}
+				activeImpactView.refresh();
+			})),
 			commands.registerCommand(`vscode-sourceorbit.objects.goToFile`, ((node: ILEObjectTreeItem) => {
 				if (node && node.resourceUri) {
 					workspace.openTextDocument(node.resourceUri).then(doc => {
@@ -102,7 +120,7 @@ export async function activate(context: ExtensionContext) {
 
 		// Impact for current active editor
 		const activeTextEditor = window.activeTextEditor;
-		if(activeTextEditor) {
+		if (activeTextEditor) {
 			activeImpactView.showImpactFor([activeTextEditor.document.uri]);
 		}
 	}

--- a/vs/client/src/tasks.ts
+++ b/vs/client/src/tasks.ts
@@ -3,7 +3,7 @@ import { LanguageClientManager } from './languageClientManager';
 
 export namespace SourceOrbitTask {
 	interface SourceOrbitTask extends TaskDefinition {
-		builder: "bob" | "make" | "json";
+		builder: "bob" | "make" | "imd" | "json";
 	}
 
 	export function initializeTaskProvider(context: ExtensionContext) {

--- a/vs/client/src/views/impactView/index.ts
+++ b/vs/client/src/views/impactView/index.ts
@@ -5,7 +5,7 @@ import { ILEImpactedObjectTreeItem } from './ileImpactedObjectTreeItem';
 export class ImpactView implements TreeDataProvider<any> {
 	private _onDidChangeTreeData: EventEmitter<TreeItem | undefined | null | void> = new EventEmitter<TreeItem | undefined | null | void>();
 	readonly onDidChangeTreeData: Event<TreeItem | undefined | null | void> = this._onDidChangeTreeData.event;
-	private impactOf: Uri[] = [];
+	public impactOf: Uri[] = [];
 
 	refresh() {
 		this._onDidChangeTreeData.fire();

--- a/vs/package.json
+++ b/vs/package.json
@@ -111,6 +111,18 @@
 				"icon": "$(wand)"
 			},
 			{
+				"command": "vscode-sourceorbit.objects.refreshActiveImpactView",
+				"category": "Source Orbit",
+				"title": "Refresh",
+				"icon": "$(refresh)"
+			},
+			{
+				"command": "vscode-sourceorbit.objects.refreshGitImpactView",
+				"category": "Source Orbit",
+				"title": "Refresh",
+				"icon": "$(refresh)"
+			},
+			{
 				"command": "vscode-sourceorbit.objects.goToFile",
 				"icon": "$(go-to-file)",
 				"category": "Source Orbit",
@@ -146,8 +158,28 @@
 					"when": "never"
 				},
 				{
+					"command": "vscode-sourceorbit.objects.refreshActiveImpactView",
+					"when": "never"
+				},
+				{
+					"command": "vscode-sourceorbit.objects.refreshGitImpactView",
+					"when": "never"
+				},
+				{
 					"command": "vscode-sourceorbit.objects.goToFile",
 					"when": "never"
+				}
+			],
+			"view/title": [
+				{
+					"command": "vscode-sourceorbit.objects.refreshActiveImpactView",
+					"when": "view == activeImpactView",
+					"group": "navigation@0"
+				},
+				{
+					"command": "vscode-sourceorbit.objects.refreshGitImpactView",
+					"when": "view == gitImpactView",
+					"group": "navigation@0"
 				}
 			],
 			"view/item/context": [

--- a/vs/package.json
+++ b/vs/package.json
@@ -75,24 +75,24 @@
 		},
 		"viewsWelcome": [
 			{
-			  "view": "activeImpactView",
-			  "contents": "No workspace folder opened",
-			  "when": "workspaceFolderCount == 0"
+				"view": "activeImpactView",
+				"contents": "No workspace folder opened",
+				"when": "workspaceFolderCount == 0"
 			},
 			{
-			  "view": "activeImpactView",
-			  "contents": "Open a source file to see the affected objects",
-			  "when": "workspaceFolderCount != 0"
+				"view": "activeImpactView",
+				"contents": "Open a source file to see the affected objects",
+				"when": "workspaceFolderCount != 0"
 			},
 			{
-			  "view": "gitImpactView",
-			  "contents": "No workspace folder opened",
-			  "when": "workspaceFolderCount == 0"
+				"view": "gitImpactView",
+				"contents": "No workspace folder opened",
+				"when": "workspaceFolderCount == 0"
 			},
 			{
-			  "view": "gitImpactView",
-			  "contents": "Open a Git repository to see the affected objects",
-			  "when": "workspaceFolderCount != 0"
+				"view": "gitImpactView",
+				"contents": "Open a Git repository to see the affected objects",
+				"when": "workspaceFolderCount != 0"
 			}
 		],
 		"commands": [
@@ -109,6 +109,26 @@
 				"title": "Autofix",
 				"enablement": "vscode-sourceorbit:projectExplorerLoaded == true",
 				"icon": "$(wand)"
+			},
+			{
+				"command": "vscode-sourceorbit.objects.generateBobBuildFile",
+				"category": "Source Orbit",
+				"title": "Bob"
+			},
+			{
+				"command": "vscode-sourceorbit.objects.generateMakeBuildFile",
+				"category": "Source Orbit",
+				"title": "Make"
+			},
+			{
+				"command": "vscode-sourceorbit.objects.generateImdBuildFile",
+				"category": "Source Orbit",
+				"title": "IMD"
+			},
+			{
+				"command": "vscode-sourceorbit.objects.generateJsonBuildFile",
+				"category": "Source Orbit",
+				"title": "JSON"
 			},
 			{
 				"command": "vscode-sourceorbit.objects.refreshActiveImpactView",
@@ -158,6 +178,22 @@
 					"when": "never"
 				},
 				{
+					"command": "vscode-sourceorbit.objects.generateBobBuildFile",
+					"when": "never"
+				},
+				{
+					"command": "vscode-sourceorbit.objects.generateMakeBuildFile",
+					"when": "never"
+				},
+				{
+					"command": "vscode-sourceorbit.objects.generateImdBuildFile",
+					"when": "never"
+				},
+				{
+					"command": "vscode-sourceorbit.objects.generateJsonBuildFile",
+					"when": "never"
+				},
+				{
 					"command": "vscode-sourceorbit.objects.refreshActiveImpactView",
 					"when": "never"
 				},
@@ -186,20 +222,54 @@
 				{
 					"command": "vscode-sourceorbit.objects.goToFile",
 					"when": "view =~ /^(activeImpactView|gitImpactView|projectExplorer)$/ && viewItem == ileObject",
-					"group": "inline"
+					"group": "inline@0"
 				},
 				{
 					"command": "vscode-sourceorbit.objects.loadProject",
 					"when": "view == projectExplorer && viewItem == objectsView",
-					"group": "inline"
+					"group": "inline@2"
 				},
 				{
 					"command": "vscode-sourceorbit.objects.autoFix",
 					"when": "view == projectExplorer && viewItem == objectsView",
-					"group": "inline"
+					"group": "inline@0"
+				},
+				{
+					"submenu": "vscode-sourceorbit.generateBuildFileSubmenu",
+					"when": "view == projectExplorer && viewItem == objectsView",
+					"group": "inline@1"
+				}
+			],
+			"vscode-sourceorbit.generateBuildFileSubmenu": [
+				{
+					"command": "vscode-sourceorbit.objects.generateBobBuildFile",
+					"when": "view == projectExplorer",
+					"group": "0_buildFile@0"
+				},
+				{
+					"command": "vscode-sourceorbit.objects.generateMakeBuildFile",
+					"when": "view == projectExplorer",
+					"group": "0_buildFile@1"
+				},
+				{
+					"command": "vscode-sourceorbit.objects.generateImdBuildFile",
+					"when": "view == projectExplorer",
+					"group": "0_buildFile@2"
+				},
+				{
+					"command": "vscode-sourceorbit.objects.generateJsonBuildFile",
+					"when": "view == projectExplorer",
+					"group": "0_buildFile@3"
 				}
 			]
-		}
+		},
+		"submenus": [
+			{
+				"id": "vscode-sourceorbit.generateBuildFileSubmenu",
+				"label": "Generate Build File",
+				"icon": "$(new-file)"
+			}
+		]
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run webpack",

--- a/vs/package.json
+++ b/vs/package.json
@@ -81,7 +81,7 @@
 			},
 			{
 				"view": "activeImpactView",
-				"contents": "Open a source file to see the affected objects",
+				"contents": "Open a source file to see the affected IBM i objects",
 				"when": "workspaceFolderCount != 0"
 			},
 			{
@@ -91,7 +91,7 @@
 			},
 			{
 				"view": "gitImpactView",
-				"contents": "Open a Git repository to see the affected objects",
+				"contents": "Open a Git repository to see the affected IBM i objects",
 				"when": "workspaceFolderCount != 0"
 			}
 		],

--- a/vs/package.json
+++ b/vs/package.json
@@ -123,12 +123,12 @@
 			{
 				"command": "vscode-sourceorbit.objects.generateImdBuildFile",
 				"category": "Source Orbit",
-				"title": "IMD"
+				"title": "Impact Report"
 			},
 			{
 				"command": "vscode-sourceorbit.objects.generateJsonBuildFile",
 				"category": "Source Orbit",
-				"title": "JSON"
+				"title": "JSON Report"
 			},
 			{
 				"command": "vscode-sourceorbit.objects.refreshActiveImpactView",

--- a/vs/server/package-lock.json
+++ b/vs/server/package-lock.json
@@ -24,7 +24,7 @@
 		},
 		"../../cli": {
 			"name": "@ibm/sourceorbit",
-			"version": "0.10.4",
+			"version": "0.11.1",
 			"license": "Apache 2",
 			"dependencies": {
 				"crc-32": "https://cdn.sheetjs.com/crc-32-latest/crc-32-latest.tgz"

--- a/vs/server/src/setup.ts
+++ b/vs/server/src/setup.ts
@@ -1,4 +1,4 @@
-import { BobProject, MakeProject, Targets } from '@ibm/sourceorbit';
+import { BobProject, ImpactMarkdown, MakeProject, Targets } from '@ibm/sourceorbit';
 import { Logger } from '@ibm/sourceorbit/dist/src/logger';
 import { TargetSuggestions } from '@ibm/sourceorbit/dist/src/targets';
 import fs from 'fs';
@@ -52,6 +52,11 @@ export async function generateBuildFile(workspaceUri: string, type: string) {
 			case `make`:
 				const makeProj = new MakeProject(cwd, targets);
 				fs.writeFileSync(path.join(cwd, `makefile`), makeProj.getMakefile().join(`\n`));
+				break;
+
+			case `imd`:
+				const impactMarkdown = new ImpactMarkdown(cwd, targets, []);
+				fs.writeFileSync(path.join(cwd, `impact.md`), impactMarkdown.getContent().join(`\n`));
 				break;
 
 			case `json`:


### PR DESCRIPTION
~~⚠️Please review and merge https://github.com/IBM/sourceorbit/pull/83 first and then rebase this PR as this one builds on top of it⚠️~~
### Changes
- Add `Refresh` action to both impact views
- Add `imd` build file generation support to server
- Add `Generate Build File` inline submenu with options for `Bob`, `Make`, `Impact Report`, and `JSON Report`

![image](https://github.com/user-attachments/assets/3963816a-1c4f-4a0a-89d3-bc450e60ff45)

@worksofliam Do you have a better name for the `JSON Report` or is this alright?