### PR TITLE
Fix/case_insenstive_binder

### DIFF
--- a/cli/.vscode/launch.json
+++ b/cli/.vscode/launch.json
@@ -11,7 +11,7 @@
 			"cwd": "${workspaceFolder:cli}",
 			"program": "${workspaceFolder:cli}/dist/index.js",
 			"sourceMaps": true,
-			"args": ["-d", "/Users/barry/Downloads/arcad-example", "--verbose"],
+			"args": ["-d", "/Users/barry/Downloads/stevefiles2", "--verbose"],
 			"preLaunchTask": {
 				"type": "npm",
 				"script": "webpack:dev"

--- a/cli/src/targets.ts
+++ b/cli/src/targets.ts
@@ -450,11 +450,11 @@ export class Targets {
 
 		const validStatements = module.statements.filter(s => {
 			const possibleObject = s.getObject();
-			return (possibleObject && possibleObject.name && [`STRPGMEXP`, `ENDPGMEXP`, `EXPORT`].includes(possibleObject.name));
+			return (possibleObject && possibleObject.name && [`STRPGMEXP`, `ENDPGMEXP`, `EXPORT`].includes(possibleObject.name.toUpperCase()));
 		});
 
 		for (const statement of validStatements) {
-			const currentCommand = statement.getObject().name;
+			const currentCommand = statement.getObject().name.toUpperCase();
 			if (currentCommand === `EXPORT`) {
 				const parms = statement.getParms();
 				const symbolTokens = parms[`SYMBOL`];

--- a/cli/test/fixtures/company_system/qsrvsrc/utils.bnd
+++ b/cli/test/fixtures/company_system/qsrvsrc/utils.bnd
@@ -1,3 +1,3 @@
-STRPGMEXP PGMLVL(*CURRENT)
-  EXPORT SYMBOL('TOLOWER')
-ENDPGMEXP
+strpgmexp pgmlvl(*current)
+  export symbol('TOLOWER')
+endpgmexp


### PR DESCRIPTION
Proves issue that binder source that were not all capitals were completely ignored. This corrects the target creation to ignore case of keywords, which is expected of binder source.