### PR TITLE
Fix/export_casing

### DIFF
--- a/cli/src/targets.ts
+++ b/cli/src/targets.ts
@@ -482,6 +482,9 @@ export class Targets {
 				}
 		}
 
+		// Exports are always uppercase
+		target.exports = target.exports.map(e => e.toUpperCase());
+
 		this.addNewTarget(target);
 	}
 
@@ -972,6 +975,8 @@ export class Targets {
 		// define exported functions
 		if (cache.keyword[`NOMAIN`]) {
 			ileObject.type = `MODULE`;
+
+			// Note that we store exports as uppercase.
 			ileObject.exports = cache.procedures
 				.filter((proc: any) => proc.keyword[`EXPORT`])
 				.map(ref => ref.name.toUpperCase());
@@ -1328,7 +1333,7 @@ export class Targets {
 
 				for (const exportName of target.exports) {
 					// We loop through each export of the service program and find the module that exports it
-					const foundModule = allModules.find(mod => mod.exports && mod.exports.includes(exportName));
+					const foundModule = allModules.find(mod => mod.exports && mod.exports.includes(exportName.toUpperCase()));
 					if (foundModule) {
 						const alreadyBound = target.deps.some(dep => dep.systemName === foundModule.systemName && dep.type === `MODULE`);
 						if (!alreadyBound) {

--- a/cli/test/fixtures/mixedCaseExport/qrpglesrc/modexcept.sqlrpgle
+++ b/cli/test/fixtures/mixedCaseExport/qrpglesrc/modexcept.sqlrpgle
@@ -1,0 +1,80 @@
+**free
+      //%METADATA                                                      *
+      // %TEXT module for exceptions.                                  *
+      //%EMETADATA                                                     *
+ctl-opt nomain ;
+
+  dcl-pr getRandomMethodA char(10);
+    inProdCode       char(10)  const;
+    inState          char(2)   const;
+    inEffectiveDate  date      const;
+    inSignedDate     date      const;
+    inReceivedDate   date      const;
+    inIssuedDate     date      const;
+    inExceptionID    char(10)  const;
+    inExceptionCode  char(10)  const;
+  END-PR;
+//*************************************************************************************************
+dcl-proc getRandomMethodA export;
+  dcl-pi getRandomMethodA char(10);
+    inProdCode       char(10)  const;
+    inState          char(2)   const;
+    inEffectiveDate  date      const;
+    inSignedDate     date      const;
+    inReceivedDate   date      const;
+    inIssuedDate     date      const;
+    inExceptionID    char(10)  const;
+    inExceptionCode  char(10)  const;
+  END-PI;
+  dcl-s rtAction char(10);
+
+  if sqlstt = '00000';
+    return rtAction;
+  else;
+    return '';
+  ENDIF;
+END-PROC;
+
+dcl-proc BigFootLivesInSc export;
+  dcl-pi BigFootLivesInSc ind;
+    inProdCode       char(10)  const;
+    inState          char(2)   const;
+    inEffectiveDate  date      const;
+    inStrategy       char(10)  const;
+  END-PI;
+  dcl-s authCode char(10);
+
+  authCode = getRandomMethodA(inProdCode:inState:inEffectiveDate:
+                  inEffectiveDate:inEffectiveDate:inEffectiveDate:'STRATEGY':inStrategy);
+
+  if authCode = '' or authCode = 'ALLOW';
+    return *on;
+  else;
+    return *off;
+  ENDIF;
+END-PROC;
+
+dcl-proc validateCoolness export;
+  dcl-pi  validateCoolness ind;
+    inPolYear    packed(3:0) const;
+    inPolMon     packed(2:0) const;
+    inPolSeq     packed(6:0) const;
+    inProdCode      char(10) const;
+    inStateCode     char(2)  const;
+    inTheDate       date     const;
+  END-PI;
+  dcl-s strategyID char(10);
+  dcl-s rtError    ind inz(*on);
+
+  ENDIF;
+  exec sql fetch next from allocCheck into :strategyID;
+  dow sqlstt = '00000';
+    if not BigFootLivesInSc(inProdCode:inStateCode:inTheDate:strategyID);
+      rtError = *off;
+    ENDIF;
+  ENDDO;
+
+  return rtError;
+
+END-PROC;
+

--- a/cli/test/fixtures/mixedCaseExport/qsrvsrc/modexcept.bnd
+++ b/cli/test/fixtures/mixedCaseExport/qsrvsrc/modexcept.bnd
@@ -1,0 +1,5 @@
+             strpgmexp  signature( 'V2021.02')
+                export     symbol(getRandomMethodA)
+                export     symbol(BigFootLivesInSc)
+                export     symbol(validateCoolness)
+             endpgmexp

--- a/cli/test/mixedCaseExport.test.ts
+++ b/cli/test/mixedCaseExport.test.ts
@@ -1,0 +1,47 @@
+import { beforeAll, describe, expect, test } from 'vitest';
+
+import { Targets } from '../src/targets'
+import path from 'path';
+import { getFiles } from '../src/utils';
+import { setupFixture } from './fixtures/projects';
+import { scanGlob } from '../src/extensions';
+
+const cwd = setupFixture(`mixedCaseExport`);
+
+let files = getFiles(cwd, scanGlob);
+
+async function setupScopeAnalysis(targets: Targets) {
+  targets.loadObjectsFromPaths(files);
+  const parsePromises = files.map(f => targets.parseFile(f));
+  await Promise.all(parsePromises);
+
+  expect(targets.getTargets().length).toBeGreaterThan(0);
+  targets.resolveBinder();
+}
+
+describe.skipIf(files.length === 0)(`pr with mixed case exports exports `, () => {
+  const targets = new Targets(cwd);
+
+  beforeAll(async () => {
+    await setupScopeAnalysis(targets);
+  });
+
+  test(`Correct check exports no matter the casing`, async () => {
+    const allLogs = targets.logger.getAllLogs();
+
+    const [srvPgmObj] = targets.getResolvedObjects(`SRVPGM`);
+    expect(srvPgmObj).toBeDefined();
+    expect(srvPgmObj.systemName).toBe(`MODEXCEPT`);
+    expect(srvPgmObj.type).toBe(`SRVPGM`);
+
+    const srvPgmTarget = targets.getTarget({ systemName: `MODEXCEPT`, type: `SRVPGM` });
+    expect(srvPgmTarget).toBeDefined();
+
+    expect(srvPgmTarget.deps.length).toBe(1);
+
+    expect(srvPgmTarget.exports.length).toBe(3);
+    expect(srvPgmTarget.exports).toStrictEqual(srvPgmTarget.deps[0].exports);
+
+    expect(allLogs[srvPgmObj.relativePath].length).toBe(0);
+  });
+});


### PR DESCRIPTION
* Fixes issue where casing of binder exports were not ignored - now they are correctly case-insensitive.
* Adds new test case to prove this.