### PR TITLE
.objrefs problem with so -bf imd

### DIFF
--- a/cli/src/builders/imd.ts
+++ b/cli/src/builders/imd.ts
@@ -180,7 +180,7 @@ export class ImpactMarkdown {
 
     this.targets.getResolvedObjects().forEach(ileObject => {
 
-      let logs = this.targets.logger.getLogsFor(ileObject.relativePath);
+      let logs = this.targets.logger.getLogsFor(ileObject.relativePath) || [];
       let parents = this.targets.getTargets().filter(t => t.deps.some(d => d.systemName === ileObject.systemName && d.type === ileObject.type));
       let children = this.targets.getTarget(ileObject)?.deps || [];
 


### PR DESCRIPTION
This pull request includes a small but important change to the `ImpactMarkdown` class in the `cli/src/builders/imd.ts` file. The change ensures that the `logs` variable is initialized to an empty array if no logs are found for the given `ileObject.relativePath`.

* [`cli/src/builders/imd.ts`](diffhunk://#diff-72abe9ad440e7720a7d1f75d0dcd1eba499a295e0c902d1dec91f79c0564e559L183-R183): Modified the `getLogsFor` method to return an empty array if no logs are found for the `ileObject.relativePath`.the same issue as mentioned #79 (.objrefs problem with so -bf imd).
