### PR TITLE
Fix edge cases for long names and fix handling of `.test` to still apply other rules

### DIFF
--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -58,7 +58,7 @@ export function getSystemNameFromPath(inputName: string) {
 		systemName = `T${systemName}`;
 	}
 
-	// System name could exceed 10 characters (ie. if prefix is long or because of T prefix) so substring one last time
+	// System name could exceed 10 characters (ie. if prefix is long, name is all uppercase, or because of T prefix) so substring one last time
 	return systemName.substring(0, 10).toUpperCase();
 }
 

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -11,15 +11,20 @@ import { ReadFileSystem } from "./readFileSystem";
 
 export function getSystemNameFromPath(inputName: string) {
 	const isTest = inputName.toUpperCase().endsWith(`.TEST`);
-	let baseName = inputName.includes(`-`) ? inputName.split(`-`)[0] : inputName;
-
 	if (isTest) {
 		// Remove the .TEST part
-		baseName = baseName.substring(0, baseName.length - 5);
+		inputName = inputName.substring(0, inputName.length - 5);
 	}
 
-	// If the name is of valid length, return it
-	if (baseName.length <= 10 && !isTest) {
+	const baseName = inputName.includes(`-`) ? inputName.split(`-`)[0] : inputName;
+
+	// Test -> If the name with test prefix T is of valid length, return it
+	if (isTest && `T${baseName}`.length <= 10) {
+		return `T${baseName}`.toUpperCase();
+	}
+
+	// Non-test -> If the name is of valid length, return it
+	if (!isTest && baseName.length <= 10) {
 		return baseName.toUpperCase();
 	}
 
@@ -33,15 +38,10 @@ export function getSystemNameFromPath(inputName: string) {
 		name = parts[1];
 	}
 
-	if (isTest) {
-		prefix = `T`;
-		name = name.toUpperCase();
-	}
-
 	// We start the system name with the suppliedPrefix
 	let systemName = prefix;
 
-	for (let i = 0; i < name.length && systemName.length <= 10; i++) {
+	for (let i = 0; i < name.length && systemName.length < 10; i++) {
 		const char = name[i];
 		if (char === char.toUpperCase() || i === 0) {
 			systemName += char;
@@ -53,7 +53,13 @@ export function getSystemNameFromPath(inputName: string) {
 		systemName = name.substring(0, 10);
 	}
 
-	return systemName.toUpperCase();
+	// If it is a test, we prefix it with T
+	if (isTest) {
+		systemName = `T${systemName}`;
+	}
+
+	// System name could exceed 10 characters (ie. if prefix is long or because of T prefix) so substring one last time
+	return systemName.substring(0, 10).toUpperCase();
 }
 
 /**
@@ -172,7 +178,7 @@ export function getReferenceObjectsFrom(content: string) {
 	return pseudoObjects;
 }
 
-export function fromCl(cl: string): {command: string, parameters: CommandParameters} {
+export function fromCl(cl: string): { command: string, parameters: CommandParameters } {
 	let gotCommandnName = false;
 	let parmDepth = 0;
 
@@ -253,7 +259,7 @@ export function toCl(command: string, parameters?: CommandParameters) {
 }
 
 export function checkFileExists(file) {
-  return fs.promises.access(file, fs.constants.F_OK)
+	return fs.promises.access(file, fs.constants.F_OK)
 		.then(() => true)
 		.catch(() => false)
 }

--- a/cli/test/environment.test.ts
+++ b/cli/test/environment.test.ts
@@ -47,7 +47,13 @@ describe(`Deterministic system name`, () => {
   test('Basic name with underscore', () => {
     expect(getSystemNameFromPath(`ab_cd`)).toBe(`AB_CD`);
   })
-  test('Long form name', () => {
+  test('Long form lowercase', () => {
+    expect(getSystemNameFromPath(`thisisasuperlongname`)).toBe(`THISISASUP`);
+  })
+  test('Long form uppercase', () => {
+    expect(getSystemNameFromPath(`THISISASUPERLONGNAME`)).toBe(`THISISASUP`);
+  })
+  test('Long form camel case', () => {
     expect(getSystemNameFromPath(`thisIsASuperLongName`)).toBe(`TIASLN`);
   })
   test('With capitals', () => {
@@ -56,11 +62,47 @@ describe(`Deterministic system name`, () => {
   test('With underscore', () => {
     expect(getSystemNameFromPath(`ua_fetchUserData`)).toBe(`UAFUD`);
   })
+  test('With long underscore', () => {
+    expect(getSystemNameFromPath(`abcdefhijkl_fetchUserData`)).toBe(`ABCDEFHIJK`);
+  })
   test('Bob prefix name A', () => {
     expect(getSystemNameFromPath(`ART200-Work_with_article`)).toBe(`ART200`);
   })
   test('Bob prefix name B', () => {
     expect(getSystemNameFromPath(`ART200D-Work_with_Article`)).toBe(`ART200D`);
+  })
+});
+
+describe(`Deterministic test system name`, () => {
+  test('Basic name', () => {
+    expect(getSystemNameFromPath(`abcd.test`)).toBe(`TABCD`);
+  })
+  test('Basic name with underscore', () => {
+    expect(getSystemNameFromPath(`ab_cd.test`)).toBe(`TAB_CD`);
+  })
+  test('Long form lowercase', () => {
+    expect(getSystemNameFromPath(`thisisasuperlongname.test`)).toBe(`TTHISISASU`);
+  })
+  test('Long form uppercase', () => {
+    expect(getSystemNameFromPath(`THISISASUPERLONGNAME.test`)).toBe(`TTHISISASU`);
+  })
+  test('Long form camel case', () => {
+    expect(getSystemNameFromPath(`thisIsASuperLongName.test`)).toBe(`TTIASLN`);
+  })
+  test('With capitals', () => {
+    expect(getSystemNameFromPath(`FetchUserData.test`)).toBe(`TFUD`);
+  })
+  test('With underscore', () => {
+    expect(getSystemNameFromPath(`ua_fetchUserData.test`)).toBe(`TUAFUD`);
+  })
+  test('With long underscore', () => {
+    expect(getSystemNameFromPath(`abcdefhijkl_fetchUserData.test`)).toBe(`TABCDEFHIJ`);
+  })
+  test('Bob prefix name A', () => {
+    expect(getSystemNameFromPath(`ART200-Work_with_article.test`)).toBe(`TART200`);
+  })
+  test('Bob prefix name B', () => {
+    expect(getSystemNameFromPath(`ART200D-Work_with_Article.test`)).toBe(`TART200D`);
   })
 });
 

--- a/docs/pages/general/rules.md
+++ b/docs/pages/general/rules.md
@@ -67,6 +67,7 @@ Typically, the basename of the file is also the object name. But, Source Orbit w
 | `FetchUserData.cmd`              | `FUD.CMD`        | All capitals from file name                                             |
 | `ua_fetchUserData.sqlrpgle`      | `UAFUD.MODULE`   | Prefix, followed by first post-prefix character plus following capitals |
 | `ART200D-Work_with_Article.DSPF` | `ART200D.FILE`   | Support for ibmi-bob file name                                          |
+| `empdet.test.rpgle`              | `TEMPDET.MODULE` | Prefix object with `T` for names including `.test` in the extension     |
 
 Even if you use long file names, your source code still needs to reference the object name for object resolves (not including *include directives* of course.)
 


### PR DESCRIPTION
Changes to `getSystemNameFromPath`:
- We need to `substring` an extra time at the end to handle some edge cases (Prefix with more than 10 chars, all uppercase name with more than 10 chars)
- Simplify handling of `.test` to first apply all the existing rules and then handle it at the end

New tests:
- Added test cases for above scenarios

Updated the docs as well to include an example of `.test`