### PR TITLE
Use file system provider for includes and ignore extension casing

### DIFF
--- a/cli/src/languages/rpgle.ts
+++ b/cli/src/languages/rpgle.ts
@@ -53,7 +53,7 @@ export function setupParser(targets: Targets): Parser {
 				}
 
 			} else {
-				const content = readFileSync(file, { encoding: `utf-8` });
+				const content = await targets.rfs.readFile(file);
 				includeFileCache[file] = content;
 
 				return {

--- a/cli/src/targets.ts
+++ b/cli/src/targets.ts
@@ -1042,7 +1042,7 @@ export class Targets {
 
 				const includeDetail = path.parse(include.toPath);
 
-				if (includeDetail.ext !== `.rpgleinc`) {
+				if (includeDetail.ext.toLowerCase() !== `.rpgleinc`) {
 					const possibleName = includeDetail.name.toLowerCase().endsWith(`.pgm`) ? includeDetail.name.substring(0, includeDetail.name.length - 4) : includeDetail.name;
 
 					if (this.suggestions.renames) {


### PR DESCRIPTION
Implement reading includes using the file system provider and adjust extension checks to ignore casing, aligning with IBM i rules.