### PR TITLE
Refactor handleNewRefObject method for clarity and maintainability

### DIFF
--- a/cli/src/targets/index.ts
+++ b/cli/src/targets/index.ts
@@ -207,12 +207,16 @@ export class Targets {
 		const pseudoObjects = getReferenceObjectsFrom(content);
 
 		for (const ileObject of pseudoObjects) {
-			if (!this.searchForObject(ileObject)) {
-				const key = `${ileObject.systemName}.${ileObject.type}`;
-				ileObject.reference = true;
-				this.resolvedObjects[key] = ileObject;
-			}
+			this.handleNewRefObject(ileObject);
 		};
+	}
+
+	public handleNewRefObject(ileObject: ILEObject) {
+		if (!this.searchForObject(ileObject)) {
+			const key = `${ileObject.systemName}.${ileObject.type}`;
+			ileObject.reference = true;
+			this.resolvedObjects[key] = ileObject;
+		}
 	}
 
 	public isReferenceObject(ileObject: ILEObject, remove?: boolean) {


### PR DESCRIPTION
Improve the readability and maintainability of the `handleNewRefObject` method by extracting its logic from the loop that processes pseudoObjects.