### PR TITLE
Change binding directory references and update documentation

### DIFF
--- a/cli/src/builders/environment.ts
+++ b/cli/src/builders/environment.ts
@@ -86,7 +86,7 @@ export function getDefaultCompiles(): CompileAttribute {
         entmod: `$*`,
         module: `*MODULES`,
         tgtrls: `*CURRENT`,
-        bnddir: `$(BNDDIR)`,
+        bnddir: `$(APP_BNDDIR)`,
         actgrp: `*NEW`
       }
     },
@@ -100,7 +100,7 @@ export function getDefaultCompiles(): CompileAttribute {
         dbgview: `*SOURCE`,
         tgtrls: `*CURRENT`,
         tgtccsid: `*JOB`,
-        bnddir: `$(BNDDIR)`,
+        bnddir: `$(APP_BNDDIR)`,
         dftactgrp: `*NO`
       }
     },
@@ -114,7 +114,7 @@ export function getDefaultCompiles(): CompileAttribute {
         dbgview: `*SOURCE`,
         option: `*EVENTF`,
         rpgppopt: `*LVL2`,
-        compileopt: `TGTCCSID(*JOB) BNDDIR($(BNDDIR)) DFTACTGRP(*no)`
+        compileopt: `TGTCCSID(*JOB) BNDDIR($(APP_BNDDIR)) DFTACTGRP(*no)`
       }
     },
     "rpgle": {
@@ -226,7 +226,7 @@ export function getDefaultCompiles(): CompileAttribute {
         srvpgm: `$(BIN_LIB)/$*`,
         module: `*MODULES`,
         srcstmf: `'$<'`,
-        bnddir: `$(BNDDIR)`
+        bnddir: `$(APP_BNDDIR)`
       },
       postCommands: [
         `-system -q "ADDBNDDIRE BNDDIR($(BIN_LIB)/$(APP_BNDDIR)) OBJ((*LIBL/$* *SRVPGM *IMMED))"`

--- a/cli/test/cs_srvpgm.test.ts
+++ b/cli/test/cs_srvpgm.test.ts
@@ -84,7 +84,7 @@ describe(`pseudo tests`, () => {
     const contents = makefile.getMakefile().join(`\n`);
 
     expect(contents).toContain(`$(PREPATH)/EMPLOYEES.PGM:`);
-    expect(contents).toContain(`system "CRTPGM PGM($(BIN_LIB)/EMPLOYEES) ENTMOD(EMPLOYEES) MODULE(EMPDET EMPLOYEES) TGTRLS(*CURRENT) BNDDIR($(BNDDIR)) ACTGRP(*NEW)" > .logs/employees.splf`);
+    expect(contents).toContain(`system "CRTPGM PGM($(BIN_LIB)/EMPLOYEES) ENTMOD(EMPLOYEES) MODULE(EMPDET EMPLOYEES) TGTRLS(*CURRENT) BNDDIR($(APP_BNDDIR)) ACTGRP(*NEW)" > .logs/employees.splf`);
 
     expect(contents).not.toContain(`EMPDET.SRVPGM`); // Ensure no service program is created
     expect(contents).toContain(`EMPDET.MODULE`);

--- a/cli/test/cs_with_bnddir.test.ts
+++ b/cli/test/cs_with_bnddir.test.ts
@@ -65,7 +65,7 @@ describe(`pseudo tests`, () => {
     expect(contents).toContain(`BNDDIR=($(BIN_LIB)/$(APP_BNDDIR))\n`);
 
     expect(contents).toContain(`$(PREPATH)/EMPLOYEES.PGM: $(PREPATH)/EMPLOYEE.FILE $(PREPATH)/EMPS.FILE $(PREPATH)/EMPDET.SRVPGM`);
-    expect(contents).toContain(`system "CRTSQLRPGI OBJ($(BIN_LIB)/EMPLOYEES) SRCSTMF('qrpglesrc/employees.pgm.sqlrpgle') COMMIT(*NONE) DBGVIEW(*SOURCE) OPTION(*EVENTF) RPGPPOPT(*LVL2) COMPILEOPT('TGTCCSID(*JOB) BNDDIR($(BNDDIR)) DFTACTGRP(*no)')"`);
+    expect(contents).toContain(`system "CRTSQLRPGI OBJ($(BIN_LIB)/EMPLOYEES) SRCSTMF('qrpglesrc/employees.pgm.sqlrpgle') COMMIT(*NONE) DBGVIEW(*SOURCE) OPTION(*EVENTF) RPGPPOPT(*LVL2) COMPILEOPT('TGTCCSID(*JOB) BNDDIR($(APP_BNDDIR)) DFTACTGRP(*no)')"`);
 
     expect(contents).toContain(`$(PREPATH)/APP.BNDDIR: $(PREPATH)/EMPDET.SRVPGM`);
     expect(contents).toContain(`$(PREPATH)/EMPDET.SRVPGM: $(PREPATH)/EMPDET.MODULE`);

--- a/cli/test/make.test.ts
+++ b/cli/test/make.test.ts
@@ -153,7 +153,7 @@ test(`Multi-module program and service program`, async () => {
     '$(PREPATH)/MYWEBAPP.PGM: ',
     '\tliblist -c $(BIN_LIB);\\',
     '\tliblist -a $(LIBL);\\',
-    '\tsystem "CRTPGM PGM($(BIN_LIB)/MYWEBAPP) ENTMOD(MYWEBAPP) MODULE(HANDLERA HANDLERB MYWEBAPP) TGTRLS(*CURRENT) BNDDIR($(BNDDIR)) ACTGRP(*NEW)" > .logs/mywebapp.splf'
+    '\tsystem "CRTPGM PGM($(BIN_LIB)/MYWEBAPP) ENTMOD(MYWEBAPP) MODULE(HANDLERA HANDLERB MYWEBAPP) TGTRLS(*CURRENT) BNDDIR($(APP_BNDDIR)) ACTGRP(*NEW)" > .logs/mywebapp.splf'
   ].join());
 
   const webappMod = targets.getTarget({systemName: `MYWEBAPP`, type: `MODULE`});
@@ -178,7 +178,7 @@ test(`Multi-module program and service program`, async () => {
     '\t-system "DLTOBJ OBJ($(BIN_LIB)/UTILS) OBJTYPE(*SRVPGM)"',
     '\tliblist -c $(BIN_LIB);\\',
     '\tliblist -a $(LIBL);\\',
-    `\tsystem "CRTSRVPGM SRVPGM($(BIN_LIB)/UTILS) MODULE(JWTHANDLER VALIDATE) SRCSTMF('qsrvsrc/utils.binder') BNDDIR($(BNDDIR))" > .logs/utils.splf`,
+    `\tsystem "CRTSRVPGM SRVPGM($(BIN_LIB)/UTILS) MODULE(JWTHANDLER VALIDATE) SRCSTMF('qsrvsrc/utils.binder') BNDDIR($(APP_BNDDIR))" > .logs/utils.splf`,
     '\t-system -q "ADDBNDDIRE BNDDIR($(BIN_LIB)/$(APP_BNDDIR)) OBJ((*LIBL/UTILS *SRVPGM *IMMED))"'
   ].join());
 })

--- a/cli/test/multiModule2.test.ts
+++ b/cli/test/multiModule2.test.ts
@@ -66,7 +66,7 @@ describe(`multi_module_two tests`, () => {
     expect(runnerDepsString).toContain(`$(PREPATH)/RUNNER.MODULE`);
     expect(runnerDepsString).toContain(`$(PREPATH)/DATA.MODULE`);
 
-    expect(targetContent).toContain(`\tsystem "CRTPGM PGM($(BIN_LIB)/RUNNER) ENTMOD(RUNNER) MODULE(DB RUNNER DATA) TGTRLS(*CURRENT) BNDDIR($(BNDDIR)) ACTGRP(*NEW)" > .logs/runner.splf`);
+    expect(targetContent).toContain(`\tsystem "CRTPGM PGM($(BIN_LIB)/RUNNER) ENTMOD(RUNNER) MODULE(DB RUNNER DATA) TGTRLS(*CURRENT) BNDDIR($(APP_BNDDIR)) ACTGRP(*NEW)" > .logs/runner.splf`);
     expect(targetContent).toContain(`$(PREPATH)/RUNNER.MODULE: rpgle/runner.pgm.rpgle`);
   });
 });

--- a/cli/test/project.test.ts
+++ b/cli/test/project.test.ts
@@ -203,7 +203,7 @@ describe(`company_system tests`, () => {
       '\tliblist -c $(BIN_LIB);\\',
       '\tliblist -a $(LIBL);\\',
       [
-        `\tsystem "CRTBNDRPG PGM($(BIN_LIB)/MYPGM) SRCSTMF('qrpglesrc/mypgm.pgm.rpgle') OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT) TGTCCSID(*JOB) BNDDIR($(BNDDIR)) DFTACTGRP(*NO)" > .logs/mypgm.splf || \\`,
+        `\tsystem "CRTBNDRPG PGM($(BIN_LIB)/MYPGM) SRCSTMF('qrpglesrc/mypgm.pgm.rpgle') OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT) TGTCCSID(*JOB) BNDDIR($(APP_BNDDIR)) DFTACTGRP(*NO)" > .logs/mypgm.splf || \\`,
         `\t(system "CPYTOSTMF FROMMBR(\'$(PREPATH)/EVFEVENT.FILE/MYPGM.MBR\') TOSTMF(\'.evfevent/mypgm.evfevent\') DBFCCSID(*FILE) STMFCCSID(1208) STMFOPT(*REPLACE)"; $(SHELL) -c 'exit 1')`,
       ].join('\n')
     ].join());
@@ -218,7 +218,7 @@ describe(`company_system tests`, () => {
       '\tliblist -c $(BIN_LIB);\\',
       '\tliblist -a $(LIBL);\\',
       [
-        `\tsystem "CRTSQLRPGI OBJ($(BIN_LIB)/DEPTS) SRCSTMF('qrpglesrc/depts.pgm.sqlrpgle') COMMIT(*NONE) DBGVIEW(*SOURCE) OPTION(*EVENTF) RPGPPOPT(*LVL2) COMPILEOPT('TGTCCSID(*JOB) BNDDIR($(BNDDIR)) DFTACTGRP(*no)')" > .logs/depts.splf || \\`,
+        `\tsystem "CRTSQLRPGI OBJ($(BIN_LIB)/DEPTS) SRCSTMF('qrpglesrc/depts.pgm.sqlrpgle') COMMIT(*NONE) DBGVIEW(*SOURCE) OPTION(*EVENTF) RPGPPOPT(*LVL2) COMPILEOPT('TGTCCSID(*JOB) BNDDIR($(APP_BNDDIR)) DFTACTGRP(*no)')" > .logs/depts.splf || \\`,
         `\t(system "CPYTOSTMF FROMMBR('$(PREPATH)/EVFEVENT.FILE/DEPTS.MBR') TOSTMF('.evfevent/depts.evfevent') DBFCCSID(*FILE) STMFCCSID(1208) STMFOPT(*REPLACE)"; $(SHELL) -c 'exit 1')`,
       ].join('\n')
     ].join());
@@ -266,7 +266,7 @@ describe(`company_system tests`, () => {
       '\t-system "DLTOBJ OBJ($(BIN_LIB)/BANKING) OBJTYPE(*SRVPGM)"',
       '\tliblist -c $(BIN_LIB);\\',
       '\tliblist -a $(LIBL);\\',
-      '\tsystem "CRTSRVPGM SRVPGM($(BIN_LIB)/BANKING) MODULE(BANKING) SRCSTMF(\'qsrvsrc/banking.bnd\') BNDDIR($(BNDDIR))" > .logs/banking.splf',
+      '\tsystem "CRTSRVPGM SRVPGM($(BIN_LIB)/BANKING) MODULE(BANKING) SRCSTMF(\'qsrvsrc/banking.bnd\') BNDDIR($(APP_BNDDIR))" > .logs/banking.splf',
       '\t-system -q "ADDBNDDIRE BNDDIR($(BIN_LIB)/$(APP_BNDDIR)) OBJ((*LIBL/BANKING *SRVPGM *IMMED))"',
     ].join());
   });

--- a/cli/test/project2.test.ts
+++ b/cli/test/project2.test.ts
@@ -200,7 +200,7 @@ describe(`company_system tests`, () => {
       '\tliblist -c $(BIN_LIB);\\',
       '\tliblist -a $(LIBL);\\',
       [
-        `\tsystem "CRTBNDRPG PGM($(BIN_LIB)/MYPGM) SRCSTMF('qrpglesrc/mypgm.rpgle') OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT) TGTCCSID(*JOB) BNDDIR($(BNDDIR)) DFTACTGRP(*NO)" > .logs/mypgm.splf || \\`,
+        `\tsystem "CRTBNDRPG PGM($(BIN_LIB)/MYPGM) SRCSTMF('qrpglesrc/mypgm.rpgle') OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT) TGTCCSID(*JOB) BNDDIR($(APP_BNDDIR)) DFTACTGRP(*NO)" > .logs/mypgm.splf || \\`,
         `\t(system "CPYTOSTMF FROMMBR(\'$(PREPATH)/EVFEVENT.FILE/MYPGM.MBR\') TOSTMF(\'.evfevent/mypgm.evfevent\') DBFCCSID(*FILE) STMFCCSID(1208) STMFOPT(*REPLACE)"; $(SHELL) -c 'exit 1')`,
       ].join('\n')
     ].join());
@@ -215,7 +215,7 @@ describe(`company_system tests`, () => {
       '\tliblist -c $(BIN_LIB);\\',
       '\tliblist -a $(LIBL);\\',
       [
-        `\tsystem "CRTSQLRPGI OBJ($(BIN_LIB)/DEPTS) SRCSTMF('qrpglesrc/depts.sqlrpgle') COMMIT(*NONE) DBGVIEW(*SOURCE) OPTION(*EVENTF) RPGPPOPT(*LVL2) COMPILEOPT('TGTCCSID(*JOB) BNDDIR($(BNDDIR)) DFTACTGRP(*no)')" > .logs/depts.splf || \\`,
+        `\tsystem "CRTSQLRPGI OBJ($(BIN_LIB)/DEPTS) SRCSTMF('qrpglesrc/depts.sqlrpgle') COMMIT(*NONE) DBGVIEW(*SOURCE) OPTION(*EVENTF) RPGPPOPT(*LVL2) COMPILEOPT('TGTCCSID(*JOB) BNDDIR($(APP_BNDDIR)) DFTACTGRP(*no)')" > .logs/depts.splf || \\`,
         `\t(system "CPYTOSTMF FROMMBR('$(PREPATH)/EVFEVENT.FILE/DEPTS.MBR') TOSTMF('.evfevent/depts.evfevent') DBFCCSID(*FILE) STMFCCSID(1208) STMFOPT(*REPLACE)"; $(SHELL) -c 'exit 1')`,
       ].join('\n')
     ].join());
@@ -263,7 +263,7 @@ describe(`company_system tests`, () => {
       '\t-system "DLTOBJ OBJ($(BIN_LIB)/BANKING) OBJTYPE(*SRVPGM)"',
       '\tliblist -c $(BIN_LIB);\\',
       '\tliblist -a $(LIBL);\\',
-      '\tsystem "CRTSRVPGM SRVPGM($(BIN_LIB)/BANKING) MODULE(BANKING) SRCSTMF(\'qsrvsrc/banking.bnd\') BNDDIR($(BNDDIR))" > .logs/banking.splf',
+      '\tsystem "CRTSRVPGM SRVPGM($(BIN_LIB)/BANKING) MODULE(BANKING) SRCSTMF(\'qsrvsrc/banking.bnd\') BNDDIR($(APP_BNDDIR))" > .logs/banking.splf',
       '\t-system -q "ADDBNDDIRE BNDDIR($(BIN_LIB)/$(APP_BNDDIR)) OBJ((*LIBL/BANKING *SRVPGM *IMMED))"',
     ].join());
   });

--- a/cli/test/pseudo.test.ts
+++ b/cli/test/pseudo.test.ts
@@ -64,7 +64,7 @@ describe(`pseudo tests`, () => {
     const testerProgram = makefile.findIndex(l => l.startsWith(`$(PREPATH)/OTHER.PGM: qrpglesrc/other.pgm.sqlrpgle`));
     expect(testerProgram).toBeGreaterThan(-1);
     expect(makefile[testerProgram + 3]).toBe([
-      `\tsystem "CRTSQLRPGI OBJ($(BIN_LIB)/OTHER) SRCSTMF('qrpglesrc/other.pgm.sqlrpgle') COMMIT(*NONE) DBGVIEW(*SOURCE) OPTION(*EVENTF) RPGPPOPT(*LVL2) COMPILEOPT('TGTCCSID(273) BNDDIR($(BNDDIR)) DFTACTGRP(*no)')" > .logs/other.splf || \\`,
+      `\tsystem "CRTSQLRPGI OBJ($(BIN_LIB)/OTHER) SRCSTMF('qrpglesrc/other.pgm.sqlrpgle') COMMIT(*NONE) DBGVIEW(*SOURCE) OPTION(*EVENTF) RPGPPOPT(*LVL2) COMPILEOPT('TGTCCSID(273) BNDDIR($(APP_BNDDIR)) DFTACTGRP(*no)')" > .logs/other.splf || \\`,
       `\t(system "CPYTOSTMF FROMMBR('$(PREPATH)/EVFEVENT.FILE/OTHER.MBR') TOSTMF('.evfevent/other.evfevent') DBFCCSID(*FILE) STMFCCSID(1208) STMFOPT(*REPLACE)"; $(SHELL) -c 'exit 1')`
     ].join('\n'));
   });

--- a/docs/pages/cli/make.md
+++ b/docs/pages/cli/make.md
@@ -24,6 +24,13 @@ Next, assume that we want to do a incremental build of `ORD501.PGM`, which has
 
 So that means that 4 objects are going to be rebuilt. Usually, parents always need to be rebuilt to ensure level checking happens. Sometimes, we don't want to rebuild the children because they haven't changed (and can depend on the library list to find the existing objects). **You can use option `-nc` to ensure no target children get built** as part of the make file.
 
+### General rule for builds
+
+To ensure library lists are supported correctly, the following rules are recommended:
+
+* When building an object, always qualified the name of the object being built.
+* When referenceing an object, always use the unqualified name of the object so that the library list can be used to find the object.
+
 ### When is a incremental build right?
 
 It is always recommended to do a incremental build when working in a new branch. Ensure that you have a library of objects from a previous full build on the library list.

--- a/docs/pages/cli/make.md
+++ b/docs/pages/cli/make.md
@@ -28,7 +28,7 @@ So that means that 4 objects are going to be rebuilt. Usually, parents always ne
 
 To ensure library lists are supported correctly, the following rules are recommended:
 
-* When building an object, always qualified the name of the object being built.
+* When building an object, always use the qualified name of the object being built.
 * When referenceing an object, always use the unqualified name of the object so that the library list can be used to find the object.
 
 ### When is a incremental build right?


### PR DESCRIPTION
Update the compile options to consistently use the application binding directory. Enhance test cases and documentation to reflect changes in library list handling.

This issue was found due to the follow GHA that ran and failed. It failed to find a binding directory, which actually is available on the library list.

https://github.com/IBM/ibmi-company_system/actions/runs/16402047827/job/46342879437#step:10:124