### PR TITLE
Smaller makefiles for partial builds

### DIFF
--- a/cli/.vscode/launch.json
+++ b/cli/.vscode/launch.json
@@ -24,7 +24,7 @@
 			"cwd": "${workspaceFolder:cli}",
 			"program": "${workspaceFolder:cli}/dist/index.js",
 			"sourceMaps": true,
-			"args": ["-d", "/Users/barry/Repos/ibmi-company_system", "--verbose", "-bf", "make"],
+			"args": ["-d", "/Users/barry/Repos/ibmi-company_system", "--verbose", "-bf", "make", "-f", "qrpglesrc/employees.pgm.sqlrpgle"],
 			"preLaunchTask": {
 				"type": "npm",
 				"script": "webpack:dev"

--- a/cli/src/builders/make/index.ts
+++ b/cli/src/builders/make/index.ts
@@ -188,7 +188,7 @@ export class MakeProject {
 			``,
 			...this.generateTargets(specificObjects),
 			``,
-			...this.generateGenericRules()
+			...this.generateGenericRules(specificObjects)
 		];
 	}
 
@@ -275,8 +275,11 @@ export class MakeProject {
 		return lines;
 	}
 
-	public generateGenericRules(): string[] {
+	public generateGenericRules(partialBuild?: ILEObject[]): string[] {
 		let lines = [];
+
+		// If this is a partial build, we only want to generate rules for the specific objects
+		const filterObjects: ILEObject[]|undefined = partialBuild ? this.targets.getRequiredObjects(partialBuild) : undefined;
 
 		for (const entry of Object.entries(this.settings.compiles)) {
 			let [type, data] = entry;
@@ -320,6 +323,10 @@ export class MakeProject {
 				if (objects.length > 0) {
 					for (const ileObject of objects) {
 						if (ileObject.reference) continue;
+
+						if (filterObjects && !filterObjects.some(o => o.systemName === ileObject.systemName && o.type === ileObject.type)) {
+							continue; // Skip this object
+						}
 						
 						// This is used when your object really has source
 

--- a/cli/src/builders/make/index.ts
+++ b/cli/src/builders/make/index.ts
@@ -28,7 +28,7 @@ type PartialOptions = { partial: boolean, parents: boolean };
 
 interface PartialTargets {
 	partial: ILEObject[];
-	children: ILEObject[];
+	children?: ILEObject[];
 }
 
 export class MakeProject {
@@ -231,7 +231,7 @@ export class MakeProject {
 	 * If `parents` is true, it will return all parent objects of the partial build objects, and their children/
 	 */
 	private getPartialTargets(partialBuild?: ILEObject[]): PartialTargets|undefined {
-		if (!partialBuild) {
+		if (partialBuild === undefined) {
 			return;
 		}
 
@@ -288,9 +288,9 @@ export class MakeProject {
 			)
 		}
 
-		if (buildObjects) {
+		if (buildObjects && buildObjects.children) {
 			// If we don't want the children to get built, we only generate the targets for the specific objects
-			for (const obj of buildObjects.children || []) {
+			for (const obj of buildObjects.children) {
 				if (obj.reference) continue; // Skip references
 
 				const target = this.targets.getTarget(obj);
@@ -376,7 +376,7 @@ export class MakeProject {
 					for (const ileObject of objects) {
 						if (ileObject.reference) continue;
 
-						if (buildObjects && !buildObjects.children.some(o => o.systemName === ileObject.systemName && o.type === ileObject.type)) {
+						if (buildObjects && buildObjects.children && !buildObjects.children.some(o => o.systemName === ileObject.systemName && o.type === ileObject.type)) {
 							continue; // Skip this object
 						}
 						

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -11,7 +11,7 @@ export let cliSettings = {
 	fileList: false,
 	lookupFiles: [] as string[],
 	userBranch: ``,
-	makeFileNoChildren: false,
+	makefileWithParents: false,
 	assumeSourcesArePrograms: false,
 };
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -8,9 +8,9 @@ export let cliSettings = {
 	withActions: false,
 	fixIncludes: false,
 	autoRename: false,
-	fileList: false,
-	lookupFiles: [] as string[],
+	lookupFiles: undefined as string[]|undefined,
 	userBranch: ``,
+	makefileIsPartial: false,
 	makefileWithParents: false,
 	assumeSourcesArePrograms: false,
 };

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -67,6 +67,11 @@ async function main() {
 				warningOut(`--no-children is deprecated and is default when doing partial builds.`);
 				break;
 
+			case `-ip`:
+			case `--is-partial`:
+				cliSettings.makefileIsPartial = true;
+				break;
+
 			case `-wp`:
 			case `--with-parents`:
 				cliSettings.makefileWithParents = true;
@@ -84,7 +89,7 @@ async function main() {
 			case `-f`:
 			case `--files`:
 			case `-l`:
-				cliSettings.fileList = true;
+				cliSettings.lookupFiles = [];
 				break;
 
 			case `-h`:
@@ -132,6 +137,10 @@ async function main() {
 				console.log(``);
 				console.log(`Options specific to '-bf make':`);
 				console.log(``);
+				console.log(`\t-ip`);
+				console.log(`\t--is-partial\tWill only generate targets that are needed for`);
+				console.log(`\t\t\tthe objects that are being built.`);
+				console.log(``);
 				console.log(`\t-wp`);
 				console.log(`\t--with-parents\tUsed with '-bf make' and will add parents of`);
 				console.log(`\t\t\tobjects being partially built to the makefile.`);
@@ -140,7 +149,7 @@ async function main() {
 				break;
 
 			default:
-				if (cliSettings.fileList) {
+				if (cliSettings.lookupFiles !== undefined) {
 					cliSettings.lookupFiles.push(parms[i]);
 				}
 				break;
@@ -237,9 +246,12 @@ async function main() {
 
 			await makeProj.setupSettings();
 			
-			makeProj.setPartialWithImpacts(cliSettings.makefileWithParents);
+			makeProj.setPartialOptions({
+				partial: cliSettings.makefileIsPartial,
+				parents: cliSettings.makefileWithParents
+			})
 
-			let specificObjects: ILEObject[] | undefined = cliSettings.fileList ? cliSettings.lookupFiles.map(f => targets.getResolvedObject(path.join(cwd, f))).filter(o => o) : undefined;
+			let specificObjects: ILEObject[] | undefined = cliSettings.lookupFiles ? cliSettings.lookupFiles.map(f => targets.getResolvedObject(path.join(cwd, f))).filter(o => o) : undefined;
 			writeFileSync(path.join(cwd, `makefile`), makeProj.getMakefile(specificObjects).join(`\n`));
 			
 			break;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -64,7 +64,12 @@ async function main() {
 
 			case '-nc':
 			case '--no-children':
-				cliSettings.makeFileNoChildren = true;
+				warningOut(`--no-children is deprecated and is default when doing partial builds.`);
+				break;
+
+			case `-wp`:
+			case `--with-parents`:
+				cliSettings.makefileWithParents = true;
 				break;
 
 			case '-ap':
@@ -127,9 +132,9 @@ async function main() {
 				console.log(``);
 				console.log(`Options specific to '-bf make':`);
 				console.log(``);
-				console.log(`\t-nc`);
-				console.log(`\t--no-children\tUsed with '-bf make' and won't include children of`);
-				console.log(`\t\t\tobjects in the makefile. Useful in conjuction with '-f'.`);
+				console.log(`\t-wp`);
+				console.log(`\t--with-parents\tUsed with '-bf make' and will add parents of`);
+				console.log(`\t\t\tobjects being partially built to the makefile.`);
 				console.log(``);
 				process.exit(0);
 				break;
@@ -232,7 +237,7 @@ async function main() {
 
 			await makeProj.setupSettings();
 			
-			makeProj.setNoChildrenInBuild(cliSettings.makeFileNoChildren);
+			makeProj.setPartialWithImpacts(cliSettings.makefileWithParents);
 
 			let specificObjects: ILEObject[] | undefined = cliSettings.fileList ? cliSettings.lookupFiles.map(f => targets.getResolvedObject(path.join(cwd, f))).filter(o => o) : undefined;
 			writeFileSync(path.join(cwd, `makefile`), makeProj.getMakefile(specificObjects).join(`\n`));

--- a/cli/src/targets/index.ts
+++ b/cli/src/targets/index.ts
@@ -673,8 +673,9 @@ export class Targets {
 		}
 
 		return Object.values(this.resolvedObjects).filter(obj =>
-			(obj.extension?.toUpperCase() === extension && (obj.type === `PGM`) === shouldBeProgram) ||
-			(anyPrograms === true && obj.type === `PGM` && obj.extension.toUpperCase() === extension)
+			obj &&
+			((obj.extension?.toUpperCase() === extension && (obj.type === `PGM`) === shouldBeProgram) ||
+			(anyPrograms === true && obj.type === `PGM` && obj.extension.toUpperCase() === extension))
 		);
 	}
 

--- a/cli/src/targets/index.ts
+++ b/cli/src/targets/index.ts
@@ -700,7 +700,7 @@ export class Targets {
 	 * Returns a list of all the required objects to build this target
 	 */
 	public getRequiredObjects(bases: (ILEObject|ILEObjectTarget)[]) {
-		let deps: ILEObject[];
+		let deps: ILEObject[] = [];
 
 		const addDep = (dep: ILEObject|ILEObjectTarget) => {
 			if (deps.some(s => s.systemName === dep.systemName && s.type === dep.type)) return; // Already added

--- a/cli/src/targets/index.ts
+++ b/cli/src/targets/index.ts
@@ -706,9 +706,10 @@ export class Targets {
 			if (deps.some(s => s.systemName === dep.systemName && s.type === dep.type)) return; // Already added
 			if (dep.reference) return; // Skip references
 
-			if (`deps` in dep) {
-				if (dep.deps && dep.deps.length > 0) {
-					for (const cDep of dep.deps) {
+			const possibleTarget = ('deps' in dep ? dep : this.getTarget(dep));
+			if (possibleTarget) {
+				if (possibleTarget.deps && possibleTarget.deps.length > 0) {
+					for (const cDep of possibleTarget.deps) {
 						const d = this.getTarget(cDep) || cDep;
 						addDep(d);
 					}

--- a/cli/src/targets/index.ts
+++ b/cli/src/targets/index.ts
@@ -697,6 +697,35 @@ export class Targets {
 	}
 
 	/**
+	 * Returns a list of all the required objects to build this target
+	 */
+	public getRequiredObjects(bases: (ILEObject|ILEObjectTarget)[]) {
+		let deps: ILEObject[];
+
+		const addDep = (dep: ILEObject|ILEObjectTarget) => {
+			if (deps.some(s => s.systemName === dep.systemName && s.type === dep.type)) return; // Already added
+			if (dep.reference) return; // Skip references
+
+			if (`deps` in dep) {
+				if (dep.deps && dep.deps.length > 0) {
+					for (const cDep of dep.deps) {
+						const d = this.getTarget(cDep) || cDep;
+						addDep(d);
+					}
+				}
+			}
+
+			deps.push(dep);
+		}
+
+		for (const required of bases) {
+			addDep(required);
+		}
+
+		return deps;
+	}
+
+	/**
 	 * This is used when loading in all objects.
 	 * SQL sources can have two object names: a system name and a long name
 	 * Sadly the long name is not typically part of the path name, so we need to

--- a/cli/test/cs_srvpgm.test.ts
+++ b/cli/test/cs_srvpgm.test.ts
@@ -51,6 +51,12 @@ describe(`pseudo tests`, () => {
     expect(empdet.deps.find(f => f.systemName === `EMPLOYEE`)).toBeDefined();
     expect(empdet.deps.find(f => f.systemName === `DEPARTMENT`)).toBeDefined();
 
+    const allRequirements = targets.getRequiredObjects([empdet]);
+    expect(allRequirements.length).toBe(3);
+    expect(allRequirements.find(f => f.systemName === `EMPLOYEE` && f.type === `FILE`)).toBeDefined();
+    expect(allRequirements.find(f => f.systemName === `DEPARTMENT` && f.type === `FILE`)).toBeDefined();
+    expect(allRequirements.find(f => f.systemName === `EMPDET` && f.type === `MODULE`)).toBeDefined();
+
     const employees = targets.getTarget({systemName: `EMPLOYEES`, type: `PGM`});
     expect(employees).toBeDefined();
 
@@ -59,6 +65,16 @@ describe(`pseudo tests`, () => {
     expect(employees.deps.find(f => f.systemName === `EMPDET` && f.type === `MODULE`)).toBeDefined();
     expect(employees.deps.find(f => f.systemName === `EMPS` && f.type === `FILE`)).toBeDefined();
     expect(employees.deps.find(f => f.systemName === `EMPLOYEE` && f.type === `FILE`)).toBeDefined();
+
+    const requiredForEmployees = targets.getRequiredObjects([employees]);
+    expect(requiredForEmployees.length).toBe(6);
+
+    expect(requiredForEmployees.find(f => f.systemName === `EMPLOYEES` && f.type === `PGM`)).toBeDefined();
+    expect(requiredForEmployees.find(f => f.systemName === `EMPDET` && f.type === `MODULE`)).toBeDefined();
+    expect(requiredForEmployees.find(f => f.systemName === `EMPLOYEE` && f.type === `FILE`)).toBeDefined();
+    expect(requiredForEmployees.find(f => f.systemName === `DEPARTMENT` && f.type === `FILE`)).toBeDefined();
+    expect(requiredForEmployees.find(f => f.systemName === `EMPS` && f.type === `FILE`)).toBeDefined();
+    expect(requiredForEmployees.find(f => f.systemName === `EMPDET` && f.type === `MODULE`)).toBeDefined
   });
 
   test('ibmi-bob rules', () => {

--- a/cli/test/make.test.ts
+++ b/cli/test/make.test.ts
@@ -199,6 +199,8 @@ test('generateTargets (post-resolve)', async () => {
     `SRVPGMA`
   ]);
 
+  project.setPartialOptions({partial: true, parents: false});
+
   const targetContent = project.generateTargets([srvpgma]);
 
   console.log(targetContent.join('\n'));
@@ -220,6 +222,8 @@ test('generateTargets (post-resolve)', async () => {
   );
 
   const rules = project.generateGenericRules([srvpgma]);
+
+  console.log(rules.join('\n'));
   expect(rules).toContain(`$(PREPATH)/MODULEB.MODULE: qrpglesrc/moduleB.sqlrpgle`);
   expect(rules).toContain(`$(PREPATH)/SRVPGMA.SRVPGM: qsrvsrc/srvpgmA.bnd`);
   expect(rules).toContain(`$(PREPATH)/FILEB.FILE: qddssrc/fileB.pf`);

--- a/cli/test/make.test.ts
+++ b/cli/test/make.test.ts
@@ -181,4 +181,47 @@ test(`Multi-module program and service program`, async () => {
     `\tsystem "CRTSRVPGM SRVPGM($(BIN_LIB)/UTILS) MODULE(JWTHANDLER VALIDATE) SRCSTMF('qsrvsrc/utils.binder') BNDDIR($(BNDDIR))" > .logs/utils.splf`,
     '\t-system -q "ADDBNDDIRE BNDDIR($(BIN_LIB)/$(APP_BNDDIR)) OBJ((*LIBL/UTILS *SRVPGM *IMMED))"'
   ].join());
-})
+});
+
+test('generateTargets (post-resolve)', async () => {
+  const targets = await baseTargets(true);
+
+  targets.resolveBinder();
+
+  const project = new MakeProject(cwd, targets, new ReadFileSystem());
+
+  const srvpgma = targets.getTarget({systemName: `SRVPGMA`, type: `SRVPGM`});
+  const srvpgmaRequirements = targets.getRequiredObjects([srvpgma]);
+  expect(srvpgmaRequirements.length).toBe(3);
+  expect(srvpgmaRequirements.map(r => r.systemName)).toEqual([
+    `FILEB`,
+    `MODULEB`,
+    `SRVPGMA`
+  ]);
+
+  const targetContent = project.generateTargets([srvpgma]);
+
+  console.log(targetContent.join('\n'));
+
+  expect(targetContent).toEqual(
+    [
+      'all: .logs .evfevent library $(PREPATH)/SRVPGMA.SRVPGM',
+      '',
+      '$(PREPATH)/MODULEB.MODULE: $(PREPATH)/FILEB.FILE',
+      `$(PREPATH)/SRVPGMA.SRVPGM: $(PREPATH)/MODULEB.MODULE`,
+      ``,
+      `.logs:`,
+			`\tmkdir .logs`,
+			`.evfevent:`,
+			`\tmkdir .evfevent`,
+			`library:`,
+			`\t-system -q "CRTLIB LIB($(BIN_LIB))"`,
+    ]
+  );
+
+  const rules = project.generateGenericRules([srvpgma]);
+  expect(rules).toContain(`$(PREPATH)/MODULEB.MODULE: qrpglesrc/moduleB.sqlrpgle`);
+  expect(rules).toContain(`$(PREPATH)/SRVPGMA.SRVPGM: qsrvsrc/srvpgmA.bnd`);
+  expect(rules).toContain(`$(PREPATH)/FILEB.FILE: qddssrc/fileB.pf`);
+  expect(rules.length).toBe(39);
+});

--- a/cli/test/project.test.ts
+++ b/cli/test/project.test.ts
@@ -308,6 +308,8 @@ describe(`company_system tests`, () => {
     const makeProject = new MakeProject(project.cwd, targets, fs);
     await makeProject.setupSettings();
 
+    makeProject.setPartialWithImpacts(true);
+
     const deptsFile = targets.getTarget({systemName: `DEPTS`, type: `FILE`});
 
     // Generate targets on it's own will have BNDDIR, PGM, etc
@@ -323,10 +325,12 @@ describe(`company_system tests`, () => {
     const makeProject = new MakeProject(project.cwd, targets, fs);
     await makeProject.setupSettings();
 
-    const deptsFile = targets.getTarget({systemName: `EMPLOYEE`, type: `FILE`});
+    makeProject.setPartialWithImpacts(true);
+
+    const empFile = targets.getTarget({systemName: `EMPLOYEE`, type: `FILE`});
 
     // Generate targets on it's own will have BNDDIR, PGM, etc
-    const headerContent = makeProject.generateTargets([deptsFile]);
+    const headerContent = makeProject.generateTargets([empFile]);
 
     const allTarget = headerContent.find(l => l.startsWith(`all:`));
     expect(allTarget).toBeDefined();
@@ -352,7 +356,7 @@ describe(`company_system tests`, () => {
     const makeProject = new MakeProject(project.cwd, targets, fs);
     await makeProject.setupSettings();
 
-    makeProject.setNoChildrenInBuild(true);
+    makeProject.setPartialWithImpacts(true);
 
     const deptsFile = targets.getTarget({systemName: `EMPLOYEE`, type: `FILE`});
 
@@ -372,9 +376,6 @@ describe(`company_system tests`, () => {
     expect(allTargets).toContain(`$(PREPATH)/DEPTS.PGM`);
     expect(allTargets).toContain(`$(PREPATH)/SHOWEMPS.PGM`);
     expect(allTargets).toContain(`$(PREPATH)/GETTOTSAL.SRVPGM`);
-    
-    const deptsTargetDeps = headerContent.find(l => l.startsWith(`$(PREPATH)/DEPTS.PGM:`));
-    expect(deptsTargetDeps).toBeUndefined();
   });
 
   test(`Impact of EMPLOYEES`, () => {

--- a/cli/test/project.test.ts
+++ b/cli/test/project.test.ts
@@ -308,7 +308,7 @@ describe(`company_system tests`, () => {
     const makeProject = new MakeProject(project.cwd, targets, fs);
     await makeProject.setupSettings();
 
-    makeProject.setPartialWithImpacts(true);
+    makeProject.setPartialOptions({partial: true, parents: true});
 
     const deptsFile = targets.getTarget({systemName: `DEPTS`, type: `FILE`});
 
@@ -325,7 +325,7 @@ describe(`company_system tests`, () => {
     const makeProject = new MakeProject(project.cwd, targets, fs);
     await makeProject.setupSettings();
 
-    makeProject.setPartialWithImpacts(true);
+    makeProject.setPartialOptions({partial: false, parents: true});
 
     const empFile = targets.getTarget({systemName: `EMPLOYEE`, type: `FILE`});
 
@@ -345,18 +345,13 @@ describe(`company_system tests`, () => {
     expect(allTargets).toContain(`$(PREPATH)/DEPTS.PGM`);
     expect(allTargets).toContain(`$(PREPATH)/SHOWEMPS.PGM`);
     expect(allTargets).toContain(`$(PREPATH)/GETTOTSAL.SRVPGM`);
-    
-    const deptsTargetDeps = headerContent.find(l => l.startsWith(`$(PREPATH)/DEPTS.PGM:`));
-    expect(deptsTargetDeps).toBeDefined();
-
-    expect(deptsTargetDeps).toContain(`$(PREPATH)/DEPARTMENT.FILE`);
   });
 
   test(`Makefile targets for partial build (EMPLOYEE table) without children`, async () => {
     const makeProject = new MakeProject(project.cwd, targets, fs);
     await makeProject.setupSettings();
 
-    makeProject.setPartialWithImpacts(true);
+    makeProject.setPartialOptions({partial: false, parents: true});
 
     const deptsFile = targets.getTarget({systemName: `EMPLOYEE`, type: `FILE`});
 

--- a/cli/test/project2.test.ts
+++ b/cli/test/project2.test.ts
@@ -302,7 +302,7 @@ describe(`company_system tests`, () => {
     const makeProject = new MakeProject(project.cwd, targets, fs);
     await makeProject.setupSettings();
 
-    makeProject.setPartialWithImpacts(true);
+    makeProject.setPartialOptions({partial: false, parents: true});
 
     const deptsFile = targets.getTarget({systemName: `DEPTS`, type: `FILE`});
 
@@ -319,12 +319,14 @@ describe(`company_system tests`, () => {
     const makeProject = new MakeProject(project.cwd, targets, fs);
     await makeProject.setupSettings();
 
-    makeProject.setPartialWithImpacts(true);
+    makeProject.setPartialOptions({partial: false, parents: true});
 
-    const deptsFile = targets.getTarget({systemName: `EMPLOYEE`, type: `FILE`});
+    const employeeFile = targets.getTarget({systemName: `EMPLOYEE`, type: `FILE`});
 
     // Generate targets on it's own will have BNDDIR, PGM, etc
-    const headerContent = makeProject.generateTargets([deptsFile]);
+    const headerContent = makeProject.generateTargets([employeeFile]);
+
+    console.log(headerContent.join(`\n`));
 
     const allTarget = headerContent.find(l => l.startsWith(`all:`));
     expect(allTarget).toBeDefined();
@@ -339,18 +341,13 @@ describe(`company_system tests`, () => {
     expect(allTargets).toContain(`$(PREPATH)/DEPTS.PGM`);
     expect(allTargets).toContain(`$(PREPATH)/SHOWEMPS.PGM`);
     expect(allTargets).toContain(`$(PREPATH)/GETTOTSAL.SRVPGM`);
-    
-    const deptsTargetDeps = headerContent.find(l => l.startsWith(`$(PREPATH)/DEPTS.PGM:`));
-    expect(deptsTargetDeps).toBeDefined();
-
-    expect(deptsTargetDeps).toContain(`$(PREPATH)/DEPARTMENT.FILE`);
   });
 
   test(`Makefile targets for partial build (EMPLOYEE table) without children`, async () => {
     const makeProject = new MakeProject(project.cwd, targets, fs);
     await makeProject.setupSettings();
 
-    makeProject.setPartialWithImpacts(true);
+    makeProject.setPartialOptions({partial: false, parents: true});
 
     const empFile = targets.getTarget({systemName: `EMPLOYEE`, type: `FILE`});
 

--- a/cli/test/project2.test.ts
+++ b/cli/test/project2.test.ts
@@ -302,6 +302,8 @@ describe(`company_system tests`, () => {
     const makeProject = new MakeProject(project.cwd, targets, fs);
     await makeProject.setupSettings();
 
+    makeProject.setPartialWithImpacts(true);
+
     const deptsFile = targets.getTarget({systemName: `DEPTS`, type: `FILE`});
 
     // Generate targets on it's own will have BNDDIR, PGM, etc
@@ -316,6 +318,8 @@ describe(`company_system tests`, () => {
   test(`Makefile targets for partial build (EMPLOYEE table)`, async () => {
     const makeProject = new MakeProject(project.cwd, targets, fs);
     await makeProject.setupSettings();
+
+    makeProject.setPartialWithImpacts(true);
 
     const deptsFile = targets.getTarget({systemName: `EMPLOYEE`, type: `FILE`});
 
@@ -346,18 +350,18 @@ describe(`company_system tests`, () => {
     const makeProject = new MakeProject(project.cwd, targets, fs);
     await makeProject.setupSettings();
 
-    makeProject.setNoChildrenInBuild(true);
+    makeProject.setPartialWithImpacts(true);
 
-    const deptsFile = targets.getTarget({systemName: `EMPLOYEE`, type: `FILE`});
+    const empFile = targets.getTarget({systemName: `EMPLOYEE`, type: `FILE`});
 
     // Generate targets on it's own will have BNDDIR, PGM, etc
-    const headerContent = makeProject.generateTargets([deptsFile]);
+    const headerContent = makeProject.generateTargets([empFile]);
 
     const allTarget = headerContent.find(l => l.startsWith(`all: `));
     expect(allTarget).toBeDefined();
 
     const allTargets = allTarget.substring(5).split(` `);
-    expect(allTargets.length).toBe(8);
+    console.log(allTargets);
     expect(allTargets[0]).toBe(`.logs`);
     expect(allTargets[1]).toBe(`.evfevent`);
     expect(allTargets[2]).toBe(`library`);
@@ -366,9 +370,8 @@ describe(`company_system tests`, () => {
     expect(allTargets).toContain(`$(PREPATH)/DEPTS.PGM`);
     expect(allTargets).toContain(`$(PREPATH)/SHOWEMPS.PGM`);
     expect(allTargets).toContain(`$(PREPATH)/GETTOTSAL.SRVPGM`);
-    
-    const deptsTargetDeps = headerContent.find(l => l.startsWith(`$(PREPATH)/DEPTS.PGM:`));
-    expect(deptsTargetDeps).toBeUndefined();
+
+    console.log(headerContent.join(`\n`));
   });
 
   test(`Impact of EMPLOYEES`, () => {

--- a/docs/pages/cli/make.md
+++ b/docs/pages/cli/make.md
@@ -8,13 +8,6 @@ This section only applies if you use `-bf make`.
 
 Using `so -bf make` will generate a makefile to rebuild the entire project. This is fine when deploying to new systems. It is also possible to do incremental builds.
 
-To do an incremental build, also referred to as a partial build, you can specify the targets you want to build:
-
-```bash
-so -bf make -f 'qrpglesrc/ord500.pgm.rpgle'
-so -bf make -l `git diff --name-only origin/main origin/${GITHUB_HEAD_REF}`
-```
-
 A incremental build means building a specific targets, their parents and optionally their children. Let's assume this is our dependency tree:
 
 ```
@@ -32,6 +25,18 @@ Next, assume that we want to do a incremental build of `ORD501.PGM`, which has
 So that means that 3 objects are going to be rebuilt. Sometimes, we don't want to rebuild the children because they haven't changed (and can depend on the library list to find the existing objects).
 
 Usually, parents always need to be rebuilt to ensure level checking happens. If you use the `-wp` (with-parents) options, then the `makefile` will also include targets to rebuild the parent objects too (`ORD500`), but the `all` target will only build the specified target (`ORD501`).
+
+### Parameters for increment builds
+
+When you use `so -bf make`, you can specify the following parameters to control the incremental build:
+
+* `-f`/`-l` to specify the list of sources to build. This can be a single file or a list of files.
+    * `so -bf make -f qrpglesrc/employees.pgm.sqlrpgle` will build the `EMPLOYEES.PGM` object.
+* With `-ip` (is-partial), then only the specified objects and its dependents will be put into the `makefile`.
+    * `so -bf make -f qrpglesrc/employees.pgm.sqlrpgle -ip` 
+		* This will generate a makefile only for the specific objects.
+* With `-wp` (with-parents), then the parents of the specified objects will also be included in the `makefile`.
+    * `so -bf make -f qrpglesrc/employees.pgm.sqlrpgle -ip -wp`
 
 ### General rule for builds
 

--- a/docs/pages/cli/make.md
+++ b/docs/pages/cli/make.md
@@ -8,6 +8,13 @@ This section only applies if you use `-bf make`.
 
 Using `so -bf make` will generate a makefile to rebuild the entire project. This is fine when deploying to new systems. It is also possible to do incremental builds.
 
+To do an incremental build, also referred to as a partial build, you can specify the targets you want to build:
+
+```bash
+so -bf make -f 'qrpglesrc/ord500.pgm.rpgle'
+so -bf make -l `git diff --name-only origin/main origin/${GITHUB_HEAD_REF}`
+```
+
 A incremental build means building a specific targets, their parents and optionally their children. Let's assume this is our dependency tree:
 
 ```
@@ -22,7 +29,9 @@ Next, assume that we want to do a incremental build of `ORD501.PGM`, which has
 * one parent: `ORD500.PGM`
 * two children: `DEPARTMENT.FILE` and `DEPTS.FILE`
 
-So that means that 4 objects are going to be rebuilt. Usually, parents always need to be rebuilt to ensure level checking happens. Sometimes, we don't want to rebuild the children because they haven't changed (and can depend on the library list to find the existing objects). **You can use option `-nc` to ensure no target children get built** as part of the make file.
+So that means that 3 objects are going to be rebuilt. Sometimes, we don't want to rebuild the children because they haven't changed (and can depend on the library list to find the existing objects).
+
+Usually, parents always need to be rebuilt to ensure level checking happens. If you use the `-wp` (with-parents) options, then the `makefile` will also include targets to rebuild the parent objects too (`ORD500`), but the `all` target will only build the specified target (`ORD501`).
 
 ### When is a incremental build right?
 


### PR DESCRIPTION
As per #137, makefiles were containing the entire project even if doing partial builds.

This improves the ways that makefiles can be generated:

* `so -bf make`
    * Generates a makefile for the entire project, with the `all` target having most objects in it.
    * **This is how it works today**
* `so -bf make -f qrpglesrc/file.rpgle`
    * Generates a makefile for the entire project, but `all` is the objects for the given source files (in `-f`)
    * **This is how it works today**
* `so -bf make -f qrpglesrc/file.rpgle -ip`
    * Generates a makefile containing only targets for the specified objects and their children.
    * This results in a smaller makefile
* `so -bf make -f qrpglesrc/file.rpgle -ip -wp`
    * Generates a makefile containing targets for the specific objects, their children and their parents

---

### Examples

```
so -bf make -f qrpglesrc/newdept.pgm.sqlrpgle -ip
```

Generates:

```
all: .logs .evfevent library $(PREPATH)/NEWDEPT.PGM

$(PREPATH)/NEWDEPT.PGM: $(PREPATH)/NEWDEPT.FILE $(PREPATH)/DEPARTMENT.FILE

$(PREPATH)/NEWDEPT.PGM: qrpglesrc/newdept.pgm.sqlrpgle
   # ...

$(PREPATH)/NEWDEPT.FILE: qddssrc/newdept.dspf
   # ...

$(PREPATH)/DEPARTMENT.FILE: qsqlsrc/department.table
   # ...



```