### PR TITLE
Add methods to retrieve object map and object types in TargetsLanguageProvider

### DIFF
--- a/cli/src/targets/languages.ts
+++ b/cli/src/targets/languages.ts
@@ -61,4 +61,12 @@ export class TargetsLanguageProvider {
   public getObjectType(ext: string): ObjectType | undefined {
     return this.extensionMap[ext.toLowerCase()];
   }
+
+  public getObjectMap(): ExtensionMap {
+    return this.extensionMap;
+  }
+
+  public getObjectTypes(): ObjectType[] {
+    return Object.values(this.extensionMap);
+  }
 }


### PR DESCRIPTION
Introduce methods to access the object map and object types, enhancing the functionality of the TargetsLanguageProvider.