### PR TITLE
Improve error handling and manage copybooks

### DIFF
--- a/cli/src/targets/index.ts
+++ b/cli/src/targets/index.ts
@@ -131,6 +131,10 @@ export class Targets {
 		return path.relative(this.cwd, fullPath);
 	}
 
+	public getFull(relativePath: string) {
+		return path.join(this.cwd, relativePath);
+	}
+
 	storeResolved(localPath: string, ileObject: ILEObject) {
 		this.resolvedObjects[localPath] = ileObject;
 	}
@@ -274,9 +278,13 @@ export class Targets {
 		this.targets[`${resolvedObject.systemName}.${resolvedObject.type}`] = undefined;
 		this.resolvedSearches[`${resolvedObject.systemName}.${resolvedObject.type}`] = undefined;
 
+		if (resolvedObject.relativePath) {
+			this.resolvedObjects[this.getFull(resolvedObject.relativePath)] = undefined;
+			this.logger.flush(resolvedObject.relativePath)
+		}
+
 		// Remove possible logs
 		if (resolvedObject.relativePath) {
-			this.logger.flush(resolvedObject.relativePath)
 		}
 
 		return impactedTargets;
@@ -594,7 +602,7 @@ export class Targets {
 		};
 
 		// Replace the old resolved object with the module
-		this.storeResolved(path.join(this.cwd, basePath), newModule);
+		this.storeResolved(this.getFull(basePath), newModule);
 
 		// Create a new target for the module
 		const newModTarget = this.createOrAppend(newModule);

--- a/cli/src/targets/index.ts
+++ b/cli/src/targets/index.ts
@@ -115,6 +115,10 @@ export class Targets {
 		this.assumePrograms = assumePrograms;
 	}
 
+	public shouldAssumePrograms() {
+		return this.assumePrograms;
+	}
+
 	public setSuggestions(newSuggestions: TargetSuggestions) {
 		this.actionSuggestions = newSuggestions;
 	}

--- a/cli/src/targets/languages/clle.ts
+++ b/cli/src/targets/languages/clle.ts
@@ -41,10 +41,12 @@ export async function clleTargetCallback(targets: Targets, filePath: string, con
         }
       });
     } else {
-      targets.logger.fileLog(ileObject.relativePath, {
-        message: `Extension is '${ileObject.extension}', but Source Orbit doesn't support CLP. Is it possible the extension should use '.pgm.clle'?`,
-        type: `warning`,
-      });
+      if (!targets.shouldAssumePrograms()) {
+        targets.logger.fileLog(ileObject.relativePath, {
+          message: `Extension is '${ileObject.extension}', but CLP isn't supported. Is it possible the extension should use '.pgm.clle'?`,
+          type: `warning`,
+        });
+      }
     }
 
   } else {
@@ -61,10 +63,12 @@ export async function clleTargetCallback(targets: Targets, filePath: string, con
           }
         });
       } else {
-        targets.logger.fileLog(ileObject.relativePath, {
-          message: `Type detected as ${ileObject.type} but Source Orbit doesn't support CL modules. Is it possible the extension should include '.pgm'?`,
-          type: `warning`,
-        });
+        if (!targets.shouldAssumePrograms()) {
+          targets.logger.fileLog(ileObject.relativePath, {
+            message: `Type detected as ${ileObject.type} but CL modules aren't supported. Is it possible the extension should include '.pgm'?`,
+            type: `warning`,
+          });
+        }
       }
     }
   }

--- a/cli/src/targets/languages/rpgle.ts
+++ b/cli/src/targets/languages/rpgle.ts
@@ -106,10 +106,12 @@ export async function rpgleTargetCallback(targets: Targets, localPath: string, c
               }
             });
           } else {
-            targets.logger.fileLog(targets.getRelative(include.toPath), {
-              message: `referenced as include, but should use the '.rpgleinc' extension.`,
-              type: `warning`,
-            });
+            if (!targets.shouldAssumePrograms()) {
+              targets.logger.fileLog(targets.getRelative(include.toPath), {
+                message: `referenced as include, but should use the '.rpgleinc' extension.`,
+                type: `warning`,
+              });
+            }
           }
         }
 
@@ -180,7 +182,7 @@ export async function rpgleTargetCallback(targets: Targets, localPath: string, c
         });
       } else {
         targets.logger.fileLog(ileObject.relativePath, {
-          message: `type detected as ${ileObject.type} but NOMAIN keyword was not found. Is it possible the extension should include '.pgm'?`,
+          message: `type detected as ${ileObject.type} but NOMAIN keyword was not found.`,
           type: `warning`,
         });
       }
@@ -188,7 +190,7 @@ export async function rpgleTargetCallback(targets: Targets, localPath: string, c
 
     if (cache.keyword[`BNDDIR`]) {
       targets.logger.fileLog(ileObject.relativePath, {
-        message: `has the BNDDIR keyword. 'binders' property in iproj.json should be used instead.`,
+        message: `has the BNDDIR keyword. Binding directory should be set at global level or object level.`,
         type: `info`,
       });
     }

--- a/cli/src/targets/languages/rpgle.ts
+++ b/cli/src/targets/languages/rpgle.ts
@@ -135,6 +135,13 @@ export async function rpgleTargetCallback(targets: Targets, localPath: string, c
             line: include.line,
           });
         }
+
+        if (targets.shouldAssumePrograms()) {
+          const mistakenObject = targets.getResolvedObject(include.toPath);
+          if (mistakenObject) {
+            targets.removeObject(mistakenObject);
+          }
+        }
       });
     }
 

--- a/cli/test/assume_pgms_copy.test.ts
+++ b/cli/test/assume_pgms_copy.test.ts
@@ -1,0 +1,32 @@
+import { beforeAll, describe, expect, test } from 'vitest';
+
+import { Targets } from '../src/targets'
+import { setupFixture } from './fixtures/projects';
+import { ReadFileSystem } from '../src/readFileSystem';
+
+const cwd = setupFixture(`override_objref`);
+
+// This issue was occuring when you had two files with the same name, but different extensions.
+
+describe(`assume programs tests`, () => {
+ const project = setupFixture(`assume_pgms_copy`);
+
+  const fs = new ReadFileSystem();
+  const targets = new Targets(project.cwd, fs);
+  targets.setAssumePrograms(true);
+
+  beforeAll(async () => {
+    project.setup();
+    await targets.loadProject();
+
+    expect(targets.getTargets().length).toBeGreaterThan(0);
+    targets.resolveBinder();
+  });
+
+  test(`Ensure copybooks are not objects`, async () => {
+    const resolved = targets.getResolvedObjects();
+    const targetObjects = targets.getTargets();
+    expect(resolved.length).toBe(1);
+    expect(targetObjects.length).toBe(1);
+  })
+});

--- a/cli/test/fixtures/assume_pgms_copy/qrpgleref/scooby.rpgle
+++ b/cli/test/fixtures/assume_pgms_copy/qrpgleref/scooby.rpgle
@@ -1,0 +1,5 @@
+**free
+
+dcl-c myconstant 'Hello world';
+
+return;

--- a/cli/test/fixtures/assume_pgms_copy/qrpglesrc/hello.rpgle
+++ b/cli/test/fixtures/assume_pgms_copy/qrpglesrc/hello.rpgle
@@ -1,0 +1,8 @@
+**free
+
+/copy qrpgleref,scooby
+
+dsply myconstant;
+
+*inlr = *on;
+return;


### PR DESCRIPTION
Enhance error messages for unsupported extensions and implement logic to delete objects referenced as copybooks. Add a test case to ensure copybooks are not treated as objects.

Fixes #145.