### PR TITLE
Add header impact APIs for object resolution

### DIFF
--- a/cli/src/targets/index.ts
+++ b/cli/src/targets/index.ts
@@ -238,6 +238,32 @@ export class Targets {
 		return isRef;
 	}
 
+	public getAllHeaders() {
+		const allObjects = this.getResolvedObjects();
+		const allHeaders: string[] = [];
+		for (const obj of allObjects) {
+			if (obj.headers) {
+				for (const header of obj.headers) {
+					if (!allHeaders.includes(header)) {
+						allHeaders.push(header);
+					}
+				}
+			}
+		}
+		return allHeaders;
+	}
+
+	public getAffectedByHeader(headers: string[]): ILEObject[] {
+		const allObjects = this.getResolvedObjects();
+		const affectedObjects: ILEObject[] = [];
+		for (const obj of allObjects) {
+			if (obj.headers && headers.some(header => obj.headers.includes(header))) {
+				affectedObjects.push(obj);
+			}
+		}
+		return affectedObjects;
+	}
+
 	public removeObjectByPath(localPath: string) {
 		const resolvedObject = this.resolvedObjects[localPath];
 
@@ -719,7 +745,7 @@ export class Targets {
 	 * Sadly the long name is not typically part of the path name, so we need to
 	 * find the name inside of the source code.
 	 */
-	async sqlObjectDataFromPath(fullPath: string): Promise<ObjectRef> {
+	private async sqlObjectDataFromPath(fullPath: string): Promise<ObjectRef> {
 		const relativePath = this.getRelative(fullPath);
 
 		if (await this.fs.exists(fullPath)) {

--- a/cli/test/cs_with_bnddir.test.ts
+++ b/cli/test/cs_with_bnddir.test.ts
@@ -38,6 +38,26 @@ describe(`pseudo tests`, () => {
     expect(testModule.deps.find(f => f.systemName === `EMPDET` && f.type === `SRVPGM`)).toBeDefined();
   });
 
+  test(`We can get a list of headers`, () => {
+    const allHeaders = targets.getAllHeaders();
+    expect(allHeaders.length).toBe(2);
+    expect(allHeaders).toContain(`qrpgleref/constants.rpgleinc`);
+    expect(allHeaders).toContain(`qrpgleref/empdet.rpgleinc`);
+
+    const constantImpacts = targets.getAffectedByHeader([`qrpgleref/constants.rpgleinc`]);
+    expect(constantImpacts.length).toBe(4);
+    expect(constantImpacts.find(f => f.systemName === `DEPTS` && f.type === `PGM`)).toBeDefined();
+    expect(constantImpacts.find(f => f.systemName === `EMPLOYEES` && f.type === `PGM`)).toBeDefined();
+    expect(constantImpacts.find(f => f.systemName === `MYPGM` && f.type === `PGM`)).toBeDefined();
+    expect(constantImpacts.find(f => f.systemName === `NEWEMP` && f.type === `PGM`)).toBeDefined();
+
+    const empdetImpacts = targets.getAffectedByHeader([`qrpgleref/empdet.rpgleinc`]);
+    expect(empdetImpacts.length).toBe(3);
+    expect(empdetImpacts.find(f => f.systemName === `EMPDET` && f.type === `MODULE`)).toBeDefined();
+    expect(empdetImpacts.find(f => f.systemName === `EMPLOYEES` && f.type === `PGM`)).toBeDefined();
+    expect(empdetImpacts.find(f => f.systemName === `TEMPDETT` && f.type === `MODULE`)).toBeDefined();
+  });
+
   test('Deps are picked up for the module', () => {
     const empdet = targets.getTarget({systemName: `EMPDET`, type: `MODULE`});
     expect(empdet).toBeDefined();


### PR DESCRIPTION
Introduce methods to retrieve all headers and identify affected objects based on specified headers. This enhances the ability to analyze dependencies within the system.