### PR TITLE
Ignore unknown object types

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -177,7 +177,7 @@ async function main() {
 	let files: string[];
 
 	if (!scanGlob) {
-		scanGlob = targets.getSearchGlob();
+		scanGlob = Targets.LanguageProvider.getGlob();
 	}
 
 	try {

--- a/cli/src/targets/index.ts
+++ b/cli/src/targets/index.ts
@@ -95,10 +95,6 @@ export class Targets {
 		return ignoredObjects;
 	}
 
-	getSearchGlob(): string {
-		return Targets.LanguageProvider.getGlob();
-	}
-
 	public getCwd() {
 		return this.cwd;
 	}
@@ -139,12 +135,12 @@ export class Targets {
 		this.resolvedObjects[localPath] = ileObject;
 	}
 
-	public async loadProject(withRef?: string) {
-		if (withRef) {
-			await this.handleRefsFile(path.join(this.cwd, withRef));
+	public async loadProject(options: { withRef?: string, additionalExtensions?: string[] } = {}) {
+		if (options.withRef) {
+			await this.handleRefsFile(path.join(this.cwd, options.withRef));
 		}
 
-		const initialFiles = await this.fs.getFiles(this.cwd, this.getSearchGlob());
+		const initialFiles = await this.fs.getFiles(this.cwd, Targets.LanguageProvider.getGlob(options.additionalExtensions));
 		await this.loadObjectsFromPaths(initialFiles);
 		await Promise.allSettled(initialFiles.map(f => this.parseFile(f)));
 	}

--- a/cli/src/targets/languages.ts
+++ b/cli/src/targets/languages.ts
@@ -33,8 +33,8 @@ export class TargetsLanguageProvider {
     return this.languageTargets.map(lang => lang.extensions).flat();
   }
 
-  public getGlob() {
-    const allExtensions = this.getExtensions();
+  public getGlob(additionalExtensions: string[] = []): string {
+    const allExtensions = this.getExtensions().concat(additionalExtensions);
     return `**/*.{${allExtensions.join(`,`)},${allExtensions.map(e => e.toUpperCase()).join(`,`)}}`;
   }
 

--- a/cli/src/targets/languages.ts
+++ b/cli/src/targets/languages.ts
@@ -1,4 +1,4 @@
-import { FileOptions, ObjectType, Targets } from ".";
+import { FileOptions, ILEObject, ObjectType, Targets } from ".";
 import { clExtensions, clleTargetCallback, clObjects } from "./languages/clle";
 import { ddsExtension, ddsObjects, ddsTargetCallback } from "./languages/dds";
 import { rpgleExtensions, rpgleObjects, rpgleTargetCallback } from "./languages/rpgle";
@@ -7,7 +7,7 @@ import { binderExtensions, binderObjects, binderTargetCallback } from "./languag
 import { cmdExtensions, cmdObjects, cmdTargetCallback } from "./languages/cmd";
 import { noSourceObjects, noSourceTargetCallback, noSourceTargetObjects } from "./languages/nosrc";
 
-export type LanguageCallback = (targets: Targets, relativePath: string, content: string, options: FileOptions) => Promise<void>
+export type LanguageCallback = (targets: Targets, relativePath: string, content: string, ileObject: ILEObject) => Promise<void>
 interface LanguageGroup {
   extensions: string[];
   callback: LanguageCallback;
@@ -38,11 +38,11 @@ export class TargetsLanguageProvider {
     return `**/*.{${allExtensions.join(`,`)},${allExtensions.map(e => e.toUpperCase()).join(`,`)}}`;
   }
 
-  public async handleLanguage(targets: Targets, relativePath: string, content: string, options: FileOptions = {}) {
+  public async handleLanguage(targets: Targets, relativePath: string, content: string, ileObject: ILEObject) {
     const ext = relativePath.split('.').pop()?.toLowerCase();
     const language = this.languageTargets.find(lang => lang.extensions.includes(ext));
     if (ext && language) {
-      await language.callback(targets, relativePath, content, options);
+      await language.callback(targets, relativePath, content, ileObject);
     }
   }
 

--- a/cli/src/targets/languages/binder.ts
+++ b/cli/src/targets/languages/binder.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { CLParser, DefinitionType, Module, File } from "vscode-clle/language";
-import { FileOptions, ILEObjectTarget, Targets } from "..";
+import { FileOptions, ILEObject, ILEObjectTarget, Targets } from "..";
 import { infoOut } from "../../cli";
 import { trimQuotes } from "../../utils";
 import { ExtensionMap } from "../languages";
@@ -11,14 +11,12 @@ export const binderObjects: ExtensionMap = {
   bnd: `SRVPGM`,
 }
 
-export async function binderTargetCallback(targets: Targets, localPath: string, content: string, options: FileOptions) {
+export async function binderTargetCallback(targets: Targets, localPath: string, content: string, ileObject: ILEObject) {
   const clDocs = new CLParser();
   const tokens = clDocs.parseDocument(content);
 
   const module = new Module();
   module.parseStatements(tokens);
-
-  const ileObject = await targets.resolvePathToObject(localPath, options.text);
 
   const target: ILEObjectTarget = {
     ...ileObject,

--- a/cli/src/targets/languages/clle.ts
+++ b/cli/src/targets/languages/clle.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { CLParser, DefinitionType, Module, File } from "vscode-clle/language";
-import { FileOptions, ILEObjectTarget, Targets } from "..";
+import { FileOptions, ILEObject, ILEObjectTarget, Targets } from "..";
 import { infoOut } from "../../cli";
 import { ExtensionMap } from "../languages";
 
@@ -11,14 +11,12 @@ export const clObjects: ExtensionMap = {
   clp: `PGM`
 }
 
-export async function clleTargetCallback(targets: Targets, filePath: string, content: string, options: FileOptions) {
+export async function clleTargetCallback(targets: Targets, filePath: string, content: string, ileObject: ILEObject) {
   const clDocs = new CLParser();
   const tokens = clDocs.parseDocument(content);
 
   const module = new Module();
   module.parseStatements(tokens);
-
-  const ileObject = await targets.resolvePathToObject(filePath);
 
   const pathDetail = path.parse(filePath);
   const target: ILEObjectTarget = {

--- a/cli/src/targets/languages/cmd.ts
+++ b/cli/src/targets/languages/cmd.ts
@@ -1,4 +1,4 @@
-import { FileOptions, Targets } from "..";
+import { FileOptions, ILEObject, Targets } from "..";
 import { ExtensionMap } from "../languages";
 
 export const cmdExtensions = [`cmd`];
@@ -6,6 +6,6 @@ export const cmdObjects: ExtensionMap = {
   cmd: `CMD`
 }
 
-export async function cmdTargetCallback(targets: Targets, localPath: string, content: string, options: FileOptions) {
-  targets.resolvePathToObject(localPath, options.text);
+export async function cmdTargetCallback(targets: Targets, localPath: string, content: string, ileObject: ILEObject) {
+  // Do nothing!
 }

--- a/cli/src/targets/languages/dds.ts
+++ b/cli/src/targets/languages/dds.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { DisplayFile as dds } from "vscode-displayfile/src/dspf";
-import { FileOptions, ILEObjectTarget, Targets } from "..";
+import { FileOptions, ILEObject, ILEObjectTarget, Targets } from "..";
 import { infoOut } from "../../cli";
 import { ExtensionMap } from "../languages";
 
@@ -12,13 +12,11 @@ export const ddsObjects: ExtensionMap = {
   prtf: `FILE`
 }
 
-export async function ddsTargetCallback(targets: Targets, filePath: string, content: string, options: FileOptions) {
+export async function ddsTargetCallback(targets: Targets, filePath: string, content: string, ileObject: ILEObject) {
   const eol = content.indexOf(`\r\n`) >= 0 ? `\r\n` : `\n`;
 
   const ddsFile = new dds();
   ddsFile.parse(content.split(eol));
-
-  const ileObject = await targets.resolvePathToObject(filePath, options.text);
 
   const target: ILEObjectTarget = {
     ...ileObject,

--- a/cli/src/targets/languages/nosrc.ts
+++ b/cli/src/targets/languages/nosrc.ts
@@ -1,4 +1,4 @@
-import { Targets, FileOptions } from "..";
+import { Targets, FileOptions, ILEObject } from "..";
 import { ExtensionMap } from "../languages";
 
 export const noSourceObjects = [`dtaara`, `mnucmd`, `msgf`, `dtaq`, `bnddir`];
@@ -10,6 +10,6 @@ export const noSourceTargetObjects: ExtensionMap = {
   bnddir: `BNDDIR`
 }
 
-export async function noSourceTargetCallback(targets: Targets, localPath: string, content: string, options: FileOptions) {
-  targets.resolvePathToObject(localPath, options.text);
+export async function noSourceTargetCallback(targets: Targets, localPath: string, content: string, ileObject: ILEObject) {
+  // Do nothing!
 }

--- a/cli/src/targets/languages/sql.ts
+++ b/cli/src/targets/languages/sql.ts
@@ -37,7 +37,7 @@ export const sqlObjects: ExtensionMap = {
   'sqltrg': `PGM`
 }
 
-export async function sqlTargetCallback(targets: Targets, localPath: string, content: string, options: FileOptions) {
+export async function sqlTargetCallback(targets: Targets, localPath: string, content: string, ileObject: ILEObject) {
   const document = new Document(content);
 
   const pathDetail = path.parse(localPath);
@@ -130,16 +130,18 @@ export async function sqlTargetCallback(targets: Targets, localPath: string, con
             let hasLongName = mainDef.object.name && mainDef.object.name.length > 10 ? mainDef.object.name : undefined;
             let objectName = mainDef.object.system || trimQuotes(mainDef.object.name, `"`);
 
-            const extension = pathDetail.ext.substring(1);
+            // let ileObject: ILEObject = {
+            //   systemName: objectName.toUpperCase(),
+            //   longName: hasLongName,
+            //   type: targets.getObjectType(relativePath, mainDef.createType),
+            //   text: defaultObject.text,
+            //   relativePath,
+            //   extension
+            // }
 
-            let ileObject: ILEObject = {
-              systemName: objectName.toUpperCase(),
-              longName: hasLongName,
-              type: targets.getObjectType(relativePath, mainDef.createType),
-              text: options.text,
-              relativePath,
-              extension
-            }
+            ileObject.systemName = objectName.toUpperCase();
+            ileObject.longName = hasLongName;
+            ileObject.type = targets.getObjectType(relativePath, mainDef.createType);
 
             let suggestRename = false;
             const sqlFileName = pathDetail.name;
@@ -152,7 +154,7 @@ export async function sqlTargetCallback(targets: Targets, localPath: string, con
             }
 
             // Then make an extension suggestion
-            if (extension.toUpperCase() === `SQL` && mainDef.createType) {
+            if (ileObject.extension.toUpperCase() === `SQL` && mainDef.createType) {
               suggestRename = true;
             }
 
@@ -213,9 +215,6 @@ export async function sqlTargetCallback(targets: Targets, localPath: string, con
             if (newTarget.deps.length > 0) {
               infoOut(`Depends on: ${newTarget.deps.map(d => `${d.systemName}.${d.type}`).join(` `)}`);
             }
-
-            // So we can later resolve the path to the created object
-            targets.storeResolved(localPath, ileObject);
 
             targets.addNewTarget(newTarget);
 

--- a/cli/test/cs_srvpgm.test.ts
+++ b/cli/test/cs_srvpgm.test.ts
@@ -18,10 +18,13 @@ describe(`pseudo tests`, () => {
 
   beforeAll(async () => {
     project.setup();
-    await targets.loadProject();
+    await targets.loadProject({additionalExtensions: [`rpgleinc`]});
 
-    expect(targets.getTargets().length).toBeGreaterThan(0);
+    expect(targets.getResolvedObjects().length).toBe(13);
+    expect(targets.getResolvedObjectsByFileExtension(`rpgleinc`).length).toBe(0);
+
     targets.resolveBinder();
+    expect(targets.getTargets().length).toBeGreaterThan(0);
 
     make = new MakeProject(project.cwd, targets, fs);
     await make.setupSettings();

--- a/cli/test/cs_with_bnddir.test.ts
+++ b/cli/test/cs_with_bnddir.test.ts
@@ -102,7 +102,14 @@ describe(`pseudo tests`, () => {
     const files = bobProject.createRules();
 
     expect(files[`Rules.mk`]).toBeDefined();
-    expect(files[`Rules.mk`]).toBe(`SUBDIRS = qddssrc qrpglesrc qsqlsrc qtestsrc`);
+    expect(files[`Rules.mk`].startsWith(`SUBDIRS = `)).toBeTruthy();
+    
+    const subdirs = files[`Rules.mk`].split(`SUBDIRS = `)[1].trim().split(` `);
+    expect(subdirs.length).toBe(4);
+    expect(subdirs).toContain(`qddssrc`);
+    expect(subdirs).toContain(`qrpglesrc`);
+    expect(subdirs).toContain(`qsqlsrc`);
+    expect(subdirs).toContain(`qtestsrc`);
 
     expect(files[path.join(`qtestsrc`,`Rules.mk`)]).toBe(`TEMPDETT.MODULE: empdett.test.sqlrpgle qrpgleref/empdet.rpgleinc EMPLOYEE.FILE DEPARTMENT.FILE APP.BNDDIR`)  
     

--- a/cli/test/ddsDepsWithRefFile.test.ts
+++ b/cli/test/ddsDepsWithRefFile.test.ts
@@ -16,7 +16,7 @@ describe(`dds_refs tests with reference file`, () => {
   targets.setSuggestions({renames: true, includes: true})
   
   beforeAll(async () => {
-    await targets.loadProject(`.objrefs`);
+    await targets.loadProject({withRef: `.objrefs`});
 
     expect(targets.getTargets().length).toBeGreaterThan(0);
     targets.resolveBinder();

--- a/cli/test/overrideObjRef.test.ts
+++ b/cli/test/overrideObjRef.test.ts
@@ -1,13 +1,9 @@
-import { assert, beforeAll, describe, expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import { Targets } from '../src/targets'
 import path from 'path';
-import { MakeProject } from '../src/builders/make';
-import { getFiles } from '../src/utils';
 import { setupFixture } from './fixtures/projects';
 import { referencesFileName } from '../src/extensions';
-import { writeFileSync } from 'fs';
-import { BobProject } from '../src/builders/bob';
 import { ReadFileSystem } from '../src/readFileSystem';
 
 const cwd = setupFixture(`override_objref`);

--- a/vs/server/src/TargetsManager.ts
+++ b/vs/server/src/TargetsManager.ts
@@ -46,7 +46,7 @@ export class TargetsManager {
 
     const targets = new Targets(url, rfs);
 
-    const files = await rfs.getFiles(url, targets.getSearchGlob());
+    const files = await rfs.getFiles(url, Targets.LanguageProvider.getGlob());
 
     await targets.loadObjectsFromPaths(files);
 

--- a/vs/server/src/setup.ts
+++ b/vs/server/src/setup.ts
@@ -93,7 +93,7 @@ export async function fixProject(workspaceUri: string, suggestions: TargetSugges
 
 	const targets = new Targets(url, rfs);
 
-	const files = await rfs.getFiles(url, targets.getSearchGlob());
+	const files = await rfs.getFiles(url, Targets.LanguageProvider.getGlob());
 
 	targets.setSuggestions(suggestions);
 


### PR DESCRIPTION
Implement logic to ignore unknown object types. This allows any file path to be passed in to the Targets class, but only those with registered extensions/object types will be accounted for.

Fixes #152