### PR TITLE
Migrate source copybook fix

### DIFF
--- a/cli/src/builders/bob.ts
+++ b/cli/src/builders/bob.ts
@@ -43,8 +43,6 @@ export class BobProject {
 		return list;
 	}
 
-	public 
-
 	public createRules(): OutFiles {
 		let output: OutFiles = {};
 		const subdirs = Object.keys(this.dirTargets);

--- a/cli/src/targets/languages/rpgle.ts
+++ b/cli/src/targets/languages/rpgle.ts
@@ -79,6 +79,11 @@ export async function rpgleTargetCallback(targets: Targets, localPath: string, c
       ileObject.headers = [];
 
       cache.includes.forEach((include: IncludeStatement) => {
+        // Only process includes that are directly in this file, not nested includes
+        if (include.fromPath !== localPath) {
+          return;
+        }
+
         // RPGLE includes are always returned as posix paths
         // even on Windows. We need to do some magic to convert here for Windows systems
         include.toPath = toLocalPath(include.toPath);


### PR DESCRIPTION
## Problem

The Auto Fix was adding `/copy` statements for includes that existed in nested include files, not just the main source file.

## Root cause

When parsing RPGLE files with `withIncludes: true`, the parser recursively processes all includes and returns them all in `cache.includes`. The code was processing ALL includes without checking which file they came from.

Here's an example of what this looked like in one of my converted sources with the before and after image.

Notice lines 17, 22 and 23 in the after image.

<img width="1423" height="881" alt="image" src="https://github.com/user-attachments/assets/4f6aab11-f87a-47b2-b343-288ed25420ab" />



## Solution

I've added a filter to only process includes where `include.fromPath === localPath`, ensuring we only fix includes that are directly in the current file.


### Additional change

I also removed a rogue `public` keyword from `bob.ts`.

