### PR TITLE
Json creation in vscode extension missing imports and headers

### DIFF
--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -280,8 +280,11 @@ export function globalEntryIsValid(fullPath: string, search: string, ignoreBase?
 		}
 	}
 
-	const baseParts = fullPath.toUpperCase().split(path.sep);
-	const nameParts = search.split(path.posix.sep);
+	// Normalize path separators to forward slashes before splitting
+	// This ensures cross-platform compatibility (Windows uses \, Unix uses /)
+	const normalizedPath = fullPath.replace(/\\/g, '/');
+	const baseParts = normalizedPath.toUpperCase().split('/');
+	const nameParts = search.split('/');
 
 	// Check the preceding parts of the path match
 	if (nameParts.length > 1) {

--- a/cli/test/cs_srvpgm.test.ts
+++ b/cli/test/cs_srvpgm.test.ts
@@ -46,6 +46,21 @@ describe(`pseudo tests`, () => {
     expect(testModule.deps.find(f => f.systemName === `EMPDET` && f.type === `MODULE`)).toBeDefined();
   });
 
+  test('Imports are resolved from include files (cross-platform path fix)', () => {
+    // This test validates the fix for the path separator bug where imports
+    // from .rpgleinc files were not being resolved in the VS Code extension
+    const empdet = targets.getTarget({systemName: `EMPDET`, type: `MODULE`});
+    expect(empdet).toBeDefined();
+
+    // The EMPDET module should have imports from qrpgleref/empdet.rpgleinc
+    // This was failing before the fix because globalEntryIsValid() couldn't
+    // match paths with different separators (/ vs \)
+    expect(empdet.imports).toBeDefined();
+    expect(empdet.imports.length).toBe(2);
+    expect(empdet.imports).toContain('GETDEPTDETAIL');
+    expect(empdet.imports).toContain('GETEMPLOYEEDETAIL');
+  });
+
   test('Deps are picked up for the module', () => {
     const empdet = targets.getTarget({systemName: `EMPDET`, type: `MODULE`});
     expect(empdet).toBeDefined();

--- a/cli/test/utils.test.ts
+++ b/cli/test/utils.test.ts
@@ -12,4 +12,72 @@ describe(`util tests`, () => {
     expect(globalEntryIsValid(`/RPGLEREPL/QRPGLEREF/REPL_USR.RPGLEINC`, `QRPGLEREF/REPL_USR.*`)).toBeTruthy();
     expect(globalEntryIsValid(`/RPGLEREPL/BND/REPL_USR.BND`, `REPL_USR.*`)).toBeTruthy();
   });
+
+  it(`should handle mixed path separators (cross-platform fix)`, () => {
+    // Windows-style paths with forward slashes (glob results on Windows)
+    expect(globalEntryIsValid(
+      `C:/Users/user/project/qrpgleref/empdet.rpgleinc`,
+      `QRPGLEREF/EMPDET.RPGLEINC`
+    )).toBeTruthy();
+
+    // Windows-style paths with backslashes - this is the key fix
+    expect(globalEntryIsValid(
+      `C:\\Users\\user\\project\\qrpgleref\\empdet.rpgleinc`,
+      `QRPGLEREF/EMPDET.RPGLEINC`
+    )).toBeTruthy();
+
+    // Windows-style paths with mixed separators
+    expect(globalEntryIsValid(
+      `C:\\Users\\user/project\\qrpgleref/empdet.rpgleinc`,
+      `QRPGLEREF/EMPDET.RPGLEINC`
+    )).toBeTruthy();
+
+    // Unix-style paths with forward slashes
+    expect(globalEntryIsValid(
+      `/home/user/project/qrpgleref/empdet.rpgleinc`,
+      `QRPGLEREF/EMPDET.RPGLEINC`
+    )).toBeTruthy();
+
+    // Unix-style paths with backslashes (edge case, but should still work)
+    expect(globalEntryIsValid(
+      `/home/user/project/qrpgleref\\empdet.rpgleinc`,
+      `QRPGLEREF/EMPDET.RPGLEINC`
+    )).toBeTruthy();
+
+    // Non-matching filenames should return false (Windows)
+    expect(globalEntryIsValid(
+      `C:\\Users\\user\\project\\qrpgleref\\different.rpgleinc`,
+      `QRPGLEREF/EMPDET.RPGLEINC`
+    )).toBeFalsy();
+
+    // Non-matching filenames should return false (Unix)
+    expect(globalEntryIsValid(
+      `/home/user/project/qrpgleref/different.rpgleinc`,
+      `QRPGLEREF/EMPDET.RPGLEINC`
+    )).toBeFalsy();
+
+    // Wildcard matching with backslashes (Windows)
+    expect(globalEntryIsValid(
+      `C:\\Users\\user\\project\\qrpgleref\\empdet.rpgleinc`,
+      `QRPGLEREF/EMPDET.*`
+    )).toBeTruthy();
+
+    // Wildcard matching with forward slashes (Unix)
+    expect(globalEntryIsValid(
+      `/home/user/project/qrpgleref/empdet.rpgleinc`,
+      `QRPGLEREF/EMPDET.*`
+    )).toBeTruthy();
+
+    // Case insensitivity with backslashes (Windows)
+    expect(globalEntryIsValid(
+      `C:\\Users\\user\\project\\QRPGLEREF\\EMPDET.RPGLEINC`,
+      `qrpgleref/empdet.rpgleinc`
+    )).toBeTruthy();
+
+    // Case insensitivity with forward slashes (Unix)
+    expect(globalEntryIsValid(
+      `/home/user/project/QRPGLEREF/EMPDET.RPGLEINC`,
+      `qrpgleref/empdet.rpgleinc`
+    )).toBeTruthy();
+  });
 });


### PR DESCRIPTION
While generating json report in Source orbit some of the imports and headers are missing in Json in Windows. To fix this I have added a code to normalize the path.

Issue:
<img width="392" height="219" alt="image" src="https://github.com/user-attachments/assets/696cc80e-ebd1-4663-9731-d9312de2486f" />

Fix:
<img width="442" height="175" alt="image" src="https://github.com/user-attachments/assets/29cf3d55-088b-47c1-b68a-c11d43118073" />

@Mohammed-Yaseen-Ali-2081 Could you please verify the fix in Mac and review the code.

CC: @SanjulaGanepola 